### PR TITLE
Fix HTML output not rendering

### DIFF
--- a/src/components/ProfileMenu.vue
+++ b/src/components/ProfileMenu.vue
@@ -61,10 +61,16 @@ limitations under the License.
             >Cancel</v-btn
           >
         </v-card-actions>
-        <span v-if="!apiKeys.length">No API keys</span>
       </div>
-      <div class="pa-2">
+      <div v-if="apiKeys.length" class="pa-2">
         <v-table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+
           <tbody>
             <tr v-for="apiKey in apiKeys" :key="apiKey.id">
               <td>{{ apiKey.display_name }}</td>
@@ -110,12 +116,18 @@ limitations under the License.
     <template v-slot:activator="{ props }">
       <profile-picture :user="user" :size="size" v-bind="props" />
     </template>
-    <v-list>
-      <v-list-item @click="logout()">
-        <v-list-item-title>Logout</v-list-item-title>
-      </v-list-item>
+    <v-list width="200">
       <v-list-item @click="showApiKeysDialog = !showApiKeysDialog">
+        <template v-slot:prepend>
+          <v-icon size="small">mdi-key-outline</v-icon>
+        </template>
         <v-list-item-title>API keys</v-list-item-title>
+      </v-list-item>
+      <v-list-item @click="logout()">
+        <template v-slot:prepend>
+          <v-icon size="small">mdi-logout</v-icon>
+        </template>
+        <v-list-item-title>Sign out</v-list-item-title>
       </v-list-item>
     </v-list>
   </v-menu>

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -240,7 +240,9 @@ limitations under the License.
               >
                 <iframe
                   sandbox
-                  :src="getIframeSrc({ unsafe: showFilePreview })"
+                  :src="
+                    getIframeSrc({ unsafe: allowedPreview && showFilePreview })
+                  "
                   frameborder="0"
                   scrolling="yes"
                   style="width: 100%; height: 65vh"
@@ -399,10 +401,8 @@ export default {
     allowedPreview() {
       // Render unescaped HTML content in sandboxed iframe if data_type is in server side
       // provided allowlist and magic_mime is text/html.
-      return (
-        this.systemConfig.allowed_data_types_preview.includes(
-          this.file.data_type
-        ) && this.file.magic_mime == "text/html"
+      return this.systemConfig.allowed_data_types_preview.includes(
+        this.file.data_type
       );
     },
   },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -27,7 +27,7 @@ limitations under the License.
         <h2>OpenRelik</h2>
       </template>
       <template v-slot:text>
-        <v-sheet v-if="authMethods.includes('local')" class="mt-2">
+        <v-sheet v-if="authMethods.includes('local')" class="mt-3">
           <v-form @submit.prevent="">
             <v-text-field
               v-model="username"


### PR DESCRIPTION
This PR adds some smaller UI polishing (for API keys table) and it fixes one bug. There was a bug that limited the rendering of trusted output files to only files with mime-type "text/html".

