### PR TITLE
Update Celery Task Registration Endpoint

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -136,7 +136,7 @@ export default {
   },
   async getRegisteredCeleryTasks() {
     return new Promise((resolve, reject) => {
-      RestApiClient.get("/workflows/registered_tasks/")
+      RestApiClient.get("/taskqueue/tasks/registered")
         .then((response) => {
           resolve(response.data);
         })


### PR DESCRIPTION
### Summary:
Refactored the API endpoint for retrieving registered Celery tasks from `/workflows/registered_tasks/` to `/taskqueue/tasks/registered`.

### Technical Details:
* **Endpoint Change:** The REST API endpoint for fetching registered Celery tasks has been updated. The previous endpoint, `/workflows/registered_tasks/`, has been replaced with `/taskqueue/tasks/registered`. This change reflects a shift in the backend organization or a more logical grouping of task-related endpoints under `/taskqueue`.
* **Client-Side Update:** The `getRegisteredCeleryTasks` function in `src/RestApiClient.js` has been modified to reflect the new endpoint path. This ensures that client-side requests for registered tasks are directed to the correct location, preventing potential errors or broken functionality. This change is purely an endpoint URL update; the expected response format and subsequent processing within the `getRegisteredCeleryTasks` function remain unchanged.  No other code modifications were necessary apart from this single URL string update.