### PR TITLE
Improve WorkflowTreeNode background contrast in dark mode

### DIFF
--- a/src/components/WorkflowTreeNode.vue
+++ b/src/components/WorkflowTreeNode.vue
@@ -29,7 +29,11 @@ limitations under the License.
     </v-dialog>
     <span
       class="node-content"
-      :class="$vuetify.theme.name === 'dark' ? '' : 'white-background'"
+      :class="
+        $vuetify.theme.name === 'dark'
+          ? 'dark-grey-background'
+          : 'white-background'
+      "
     >
       <v-menu
         v-if="celeryTask.status_short"
@@ -241,6 +245,9 @@ export default {
 <style scoped>
 .white-background {
   background-color: white;
+}
+.dark-grey-background {
+  background-color: #181818;
 }
 .red-text {
   color: red;


### PR DESCRIPTION
### Summary:
Improved the background contrast of `WorkflowTreeNode` components in dark mode for better visibility.

### Technical Details:
*   **Dark Mode Styling Enhancement:** Modified the styling of the `WorkflowTreeNode` component in `src/components/WorkflowTreeNode.vue` to use a dark grey background (`#181818`) when the application's theme is set to dark mode.  Previously, no background color was applied in dark mode, resulting in poor contrast against the dark overall theme. This change enhances the visual separation of the nodes, making them easier to distinguish and improving the overall user experience in dark mode.

Before:
![Screenshot 2024-10-27 at 12 42 49](https://github.com/user-attachments/assets/0ad57ac3-4964-4e89-bea5-7a041dc8bb9e)

After:
![Screenshot 2024-10-27 at 12 42 35](https://github.com/user-attachments/assets/6f5d0cd4-3df8-4851-b801-1d10548f2a4f)
