### PR TITLE
Improve Task Configuration Form and Error Display

### DIFF
--- a/src/components/TaskConfigForm.vue
+++ b/src/components/TaskConfigForm.vue
@@ -34,7 +34,7 @@ limitations under the License.
         :required="field.required"
         :rules="field.required ? [(v) => !!v || 'This field is required'] : []"
         :items="field.type === 'artifacts' ? artifactNames : field.items"
-        :multiple="field.type === 'autocomplete' || 'artifacts'"
+        :multiple="field.type === 'autocomplete' || field.type === 'artifacts'"
       />
     </template>
     <v-btn

--- a/src/components/TaskResultDefault.vue
+++ b/src/components/TaskResultDefault.vue
@@ -104,8 +104,9 @@ limitations under the License.
   </div>
 
   <v-card-text v-if="task.status_short === 'FAILURE'">
-    <strong>Error: </strong>{{ task.error_exception }} <br /><br />
     <code>
+      <h3>{{ task.error_exception }}</h3>
+      <br />
       {{ task.error_traceback }}
     </code>
   </v-card-text>


### PR DESCRIPTION
### Summary:
Fixed a bug in the Task Configuration Form's multiple selection logic and improved the display of error messages in Task Results.

### Technical Details:
* **Fixed Multiple Selection Logic:**  The Task Configuration Form (`src/components/TaskConfigForm.vue`) had a bug where the `multiple` prop for the `v-autocomplete` component was always evaluating to `true` for "artifacts" fields, regardless of the intended behavior. This has been corrected by explicitly checking if the `field.type` is equal to `'autocomplete'` *or* `'artifacts'`, ensuring the `multiple` prop is set correctly based on the field type. This fix prevents unintended multiple selections in cases where it's not desired.

* **Improved Error Display:** The Task Result display (`src/components/TaskResultDefault.vue`) has been enhanced to provide clearer error messages.  Previously, the exception and traceback were displayed inline with minimal formatting.  This update adds an `h3` tag around the `task.error_exception` to make it visually distinct and easier to identify. A line break (`<br />`) has also been added to separate the exception message from the traceback, improving readability and aiding in debugging.  This makes it easier to quickly understand the nature of the error without having to parse through the entire traceback.