### PR TITLE
Update settings.js

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 const apiServerUrl =
-  import.meta.env.VITE_OPENRELIK_SERVER_URL || "http://localhost:8710";
+  import.meta.env.VITE_OPENRELIK_SERVER_URL || "http://openrelik-server:8710";
 const apiServerVersion = import.meta.env.VITE_OPENRELIK_API_VERSION || "v1";
 const authMethods = import.meta.env.VITE_OPENRELIK_AUTH_METHODS || "local";
 


### PR DESCRIPTION
changed from localhost to openrelik-server (which is resolvable by docker-dns). The connection will be established within the docker-compose network  instead of accessing the exposed localhost api-port