### PR TITLE
Metrics Dashboard with Auto-Refresh and Dynamic Resolution

### DIFF
--- a/src/components/RangeChart.vue
+++ b/src/components/RangeChart.vue
@@ -54,7 +54,7 @@ export default {
     },
     resolution: {
       type: String,
-      default: "5m",
+      default: "1m",
     },
   },
   data() {
@@ -140,6 +140,9 @@ export default {
   },
   mounted() {
     this.getTaskMetrics();
+    this.$eventBus.on("refresh-chart-data", () => {
+      this.getTaskMetrics();
+    });
   },
   watch: {
     range: "getTaskMetrics",


### PR DESCRIPTION
### Summary:
This update improves the Metrics dashboard by adding an auto-refresh feature and dynamically adjusting the chart resolution based on the selected time range.  This provides a more user-friendly and informative monitoring experience.

### Technical Details:

*   **Auto-Refresh Functionality:**  Introduced an auto-refresh feature to the Metrics dashboard. Users can now select a refresh interval (e.g., 15 seconds, 1 minute, 5 minutes) from a dropdown menu.  A manual refresh button has also been added next to the auto-refresh dropdown to allow users to refresh the data on demand.  This eliminates the need for manual page refreshes and provides near real-time monitoring capabilities. The refresh leverages an event bus to trigger data updates in the RangeChart component.

*   **Dynamic Chart Resolution:** Implemented dynamic resolution adjustment for the charts. The `step` and `resolution` props of the `RangeChart` component are now calculated automatically based on the selected time `range`. This ensures that the charts display data at an appropriate granularity, preventing overcrowding and improving readability. For instance, if the user selects a range of "Last hour", the resolution is set to 1 minute, while selecting "Last 30 days" sets the resolution to 1 day. This logic is encapsulated within the `updateStepAndResolution` method.

*   **Simplified Range & Resolution Options:** Revised the range and resolution options to provide a more intuitive user experience. Renamed "Step" to "Resolution" for clarity and adjusted the available options. Resolution and range dropdowns now offer more meaningful and commonly used timeframes. The step is now automatically determined based on range, thus the step dropdown has been removed to simplify the interface and prevent potentially conflicting settings.

*   **Event Bus Integration:** Utilized the `$eventBus` to communicate between the `Metrics.vue` component and the `RangeChart.vue` component. This enables the refresh functionality to trigger data updates in the charts without directly coupling the components. The `RangeChart` component now listens for the `refresh-chart-data` event and calls `getTaskMetrics` to update the chart when the event is emitted.

*   **Component Lifecycle Management:** Implemented proper lifecycle management for the refresh interval timer. The `resetRefreshInterval` method clears any existing timers before setting a new one, preventing multiple timers from running concurrently. The timer is also cleared in the `beforeUnmount` lifecycle hook to avoid memory leaks.