### PR TITLE
Improve Task Monitoring Metrics

### DIFF
--- a/src/views/Metrics.vue
+++ b/src/views/Metrics.vue
@@ -109,9 +109,19 @@ export default {
       ],
       metricCharts: [
         {
-          name: "Total tasks",
-          metric: "celery_task_received_total",
+          name: "Total active tasks",
+          metric: "celery_task_started_total",
           aggregate: true,
+        },
+        {
+          name: "Total tasks in queue",
+          metric: "celery_queue_length_total",
+          aggregate: true,
+        },
+        {
+          name: "Tasks in queue",
+          metric: "celery_queue_length_total",
+          aggregate: false,
         },
         {
           name: "Tasks recieved",


### PR DESCRIPTION
### Summary:
Improved the Celery task monitoring metrics displayed on the Metrics page to provide more granular insights into task queue activity and active tasks.

### Technical Details:
* **Added Active Task Metric:** Introduced a new metric, "Total active tasks," using `celery_task_started_total`. This provides visibility into the number of tasks currently being processed by Celery workers.  This helps monitor system load and identify potential bottlenecks.
* **Added Queue Length Metrics:** Implemented two metrics related to queue length:
    * "Total tasks in queue" (aggregated): Shows the total number of tasks across all queues. This gives a high-level overview of pending work.  The aggregation provides a single, concise view of the overall queue backlog.
    * "Tasks in queue" (non-aggregated): Displays the length of individual queues. This allows for more detailed analysis of queue behavior and identification of specific queues with backlogs. The non-aggregated view allows operators to pinpoint specific queues experiencing issues.
* **Replaced "Total tasks" Metric:** Removed the less informative "Total tasks" metric (`celery_task_received_total`) and replaced it with more relevant metrics focused on active tasks and queue lengths.  This change prioritizes real-time system status over cumulative task counts.
* **Added `aggregate` Property:** Introduced the `aggregate` property to the `metricCharts` configuration.  This boolean value controls whether a given metric is displayed as an aggregate across all instances or broken down individually. This allows for flexible display of metrics based on their nature and desired level of granularity.