### PR TITLE
Relocate and Rename "New Folder" Button

### DIFF
--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -366,7 +366,7 @@ limitations under the License.
         class="text-none custom-border-color"
         prepend-icon="mdi-folder-plus-outline"
         @click="showNewFolderDialog = true"
-        >New folder</v-btn
+        >New subfolder</v-btn
       >
       <v-btn
         v-if="!isWorkflowFolder && canEdit"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -44,17 +44,30 @@ limitations under the License.
   </v-dialog>
 
   <v-card variant="flat" color="transparent">
-    <v-tabs v-model="activeTab">
-      <v-tab
-        v-for="tab in tabs"
-        :key="tab.value"
-        :value="tab.value"
-        class="text-none"
-        :prepend-icon="tab.icon"
-        @click="updateRoute(tab.routeName)"
-        >{{ tab.name }}</v-tab
-      >
-    </v-tabs>
+    <v-row align="center">
+      <v-col cols="auto">
+        <v-btn
+          variant="outlined"
+          class="text-none custom-border-color mt-2"
+          prepend-icon="mdi-folder-plus-outline"
+          @click="showNewFolderDialog = true"
+          >New folder</v-btn
+        >
+      </v-col>
+      <v-col>
+        <v-tabs v-model="activeTab">
+          <v-tab
+            v-for="tab in tabs"
+            :key="tab.value"
+            :value="tab.value"
+            class="text-none"
+            :prepend-icon="tab.icon"
+            @click="updateRoute(tab.routeName)"
+            >{{ tab.name }}</v-tab
+          >
+        </v-tabs>
+      </v-col>
+    </v-row>
     <br />
   </v-card>
 
@@ -64,14 +77,6 @@ limitations under the License.
       :transition="false"
       :reverse-transition="false"
     >
-      <v-btn
-        v-if="activeTab === 0"
-        variant="outlined"
-        class="text-none custom-border-color"
-        prepend-icon="mdi-folder-plus-outline"
-        @click="showNewFolderDialog = true"
-        >New folder</v-btn
-      >
       <folder-list
         :items="folders"
         :is-home-view="true"


### PR DESCRIPTION
### Summary:
Moved the "New Folder" button from the tabs section to above the tabs and renamed it to "New subfolder" within folder views.  A dedicated "New folder" button is now present on the home view, above the tabs.

### Technical Details:
* **Home View Change:** In `src/views/Home.vue`, the "New folder" button has been moved outside the `<v-tabs>` component and placed above it within a new `v-row` for better visual separation and accessibility. This provides a clearer call to action for creating top-level folders directly from the home screen.

* **Folder View Change:**  In `src/views/Folder.vue`, the "New folder" button has been renamed to "New subfolder". This provides clearer context within a folder view, indicating that clicking the button will create a folder *within* the currently viewed folder.

* **Button Relocation:**  Removing the "New folder" button from within the `<v-tabs>` component in `Home.vue` simplifies the tab structure and ensures the button's visibility is not dependent on the active tab.  This change improves the overall user experience by providing a consistent location for folder creation regardless of the active tab.