### PR TITLE
Adjust File Size Limit for GenAI Processing

### DIFF
--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -220,7 +220,7 @@ limitations under the License.
                 isTextFormat &&
                 file.summaries &&
                 !file.summaries.length &&
-                file.filesize < fileSizeLimit
+                file.filesize < genAISizeLimit
               "
               variant="outlined"
               class="text-none mt-4 custom-border-color"
@@ -379,6 +379,7 @@ export default {
       fileContentLoading: false,
       workflows: [],
       fileSizeLimit: 10485760,
+      genAISizeLimit: 1048576,
       activeTab: null,
       tabs: [
         {


### PR DESCRIPTION
### Summary
Updated the file size limit for GenAI processing to be 1MB, separate from the general filesize limit.

### Technical Details:
*   **New `genAISizeLimit` Variable:** Added a new data property `genAISizeLimit` to the `File.vue` component, initialized to 1048576 (1MB). This limit is specifically for determining whether a file is eligible for GenAI summarization.
*   **Conditional Rendering Adjustment:** The condition for rendering the "Generate Summary" button for GenAI processing now uses `file.filesize < genAISizeLimit` instead of the general `fileSizeLimit`. This ensures that only files smaller than 1MB are considered suitable for GenAI summarization. This is presumably due to constraints around the GenAI models being used.
*   **Rationale:** This change allows for a smaller size limit for GenAI-related actions compared to the general file size limit. This change provides better resource management and prevents accidental GenAI processing of larger files, which might be too large for the GenAI models to effectively process.