### PR TITLE
Remove Cloud Disk Functionality

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -307,21 +307,6 @@ export default {
         });
     });
   },
-  async createCloudDiskFile(diskName, folderId) {
-    const requestBody = {
-      disk_name: diskName,
-      folder_id: folderId,
-    };
-    return new Promise((resolve, reject) => {
-      RestApiClient.post("/files/cloud/", requestBody)
-        .then((response) => {
-          resolve(response.data);
-        })
-        .catch((error) => {
-          reject(error);
-        });
-    });
-  },
   async deleteFile(file) {
     return new Promise((resolve, reject) => {
       RestApiClient.delete("/files/" + file.id)

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -122,39 +122,15 @@ limitations under the License.
                 :color="$vuetify.theme.name === 'dark' ? '' : 'grey-lighten-4'"
                 density="compact"
               >
-                <v-icon v-if="isCloudDisk" class="ml-4 mr-n2"
-                  >mdi-cloud-outline</v-icon
-                >
                 <v-toolbar-title
                   style="font-size: 18px"
-                  :text="isCloudDisk ? 'Cloud disk' : 'Basic properties'"
+                  text="Basic properties"
                 >
                 </v-toolbar-title>
               </v-toolbar>
               <v-divider></v-divider>
 
-              <v-table v-if="isCloudDisk" density="compact">
-                <tbody>
-                  <tr>
-                    <td>Cloud Provider</td>
-                    <td>{{ systemConfig.active_cloud.display_name }}</td>
-                  </tr>
-                  <tr>
-                    <td>Cloud Project</td>
-                    <td>{{ systemConfig.active_cloud.project_name }}</td>
-                  </tr>
-                  <tr>
-                    <td>Cloud Zone</td>
-                    <td>{{ systemConfig.active_cloud.zone }}</td>
-                  </tr>
-                  <tr>
-                    <td>Cloud Disk Name</td>
-                    <td>{{ file.filename }}</td>
-                  </tr>
-                </tbody>
-              </v-table>
-
-              <v-table v-else density="compact">
+              <v-table density="compact">
                 <tbody>
                   <tr>
                     <td>MD5</td>
@@ -420,9 +396,6 @@ export default {
         "application/javascript",
       ];
       return textFileTypes.includes(this.file.magic_mime);
-    },
-    isCloudDisk() {
-      return this.file.data_type.startsWith("cloud:");
     },
     allowedPreview() {
       // Render unescaped HTML content in sandboxed iframe if data_type is in server side

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -93,50 +93,6 @@ limitations under the License.
     </v-card>
   </v-dialog>
 
-  <!-- Add cloud disk dialog -->
-  <v-dialog v-if="isCloudEnabled" v-model="showAddCloudDisk" width="800">
-    <v-card width="800" class="mx-auto">
-      <v-card-text>
-        <h3>Add cloud disk</h3>
-        <v-list-subheader class="mb-4">
-          <v-icon size="small" color="success" class="mt-n1"
-            >mdi-check-circle-outline</v-icon
-          >
-          Connected to
-          <strong>{{ systemConfig.active_cloud.display_name }}</strong>
-          on project
-          <strong>{{ systemConfig.active_cloud.project_name }}</strong> in zone
-          <strong>{{ systemConfig.active_cloud.zone }}</strong>
-        </v-list-subheader>
-        <v-form @submit.prevent="addCloudDisk">
-          <v-text-field
-            v-model="newCloudDiskName"
-            label="Enter cloud disk name"
-            variant="outlined"
-            required
-          ></v-text-field>
-          <v-btn
-            :disabled="!newCloudDiskName"
-            type="submit"
-            color="primary"
-            variant="text"
-            class="text-none"
-            >Add</v-btn
-          >
-          <v-btn
-            variant="text"
-            class="text-none"
-            @click="
-              newCloudDiskName = '';
-              showAddCloudDisk = false;
-            "
-            >Cancel</v-btn
-          >
-        </v-form>
-      </v-card-text>
-    </v-card>
-  </v-dialog>
-
   <!-- Share folder dialog -->
   <v-dialog v-model="showSharingDialog" width="400">
     <v-card width="500" class="mx-auto">
@@ -380,14 +336,6 @@ limitations under the License.
         @click="showUpload = !showUpload"
         >Upload files</v-btn
       >
-      <v-btn
-        v-if="!isWorkflowFolder && isCloudEnabled && canEdit"
-        variant="outlined"
-        class="text-none mr-2 custom-border-color"
-        prepend-icon="mdi-cloud-plus-outline"
-        @click="showAddCloudDisk = !showAddCloudDisk"
-        >Add cloud disk</v-btn
-      >
       <v-menu v-if="files.length && canEdit">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -506,11 +454,9 @@ export default {
       myRole: { role: "" },
       selectedFiles: [],
       showUpload: false,
-      showAddCloudDisk: false,
       showNewFolderDialog: false,
       showRenameFolderDialog: false,
       showSharingDialog: false,
-      newCloudDiskName: "",
       newFolderForm: {
         name: "",
       },
@@ -539,12 +485,6 @@ export default {
         return;
       }
       return this.folder.workflows.length;
-    },
-    isCloudEnabled() {
-      if (!this.systemConfig) {
-        return;
-      }
-      return Object.keys(this.systemConfig.active_cloud).length > 0;
     },
     canEdit() {
       return this.myRole.role === "Owner" || this.myRole.role === "Editor";
@@ -677,16 +617,6 @@ export default {
           params: { folderId: this.folder.parent.id },
         });
       });
-    },
-    addCloudDisk() {
-      RestApiClient.createCloudDiskFile(
-        this.newCloudDiskName,
-        this.folder.id
-      ).then((response) => {
-        this.refreshFileListing();
-      });
-      this.showAddCloudDisk = false;
-      this.newCloudDiskName = "";
     },
   },
 


### PR DESCRIPTION
### Summary:
Removes the cloud disk functionality from the user interface.

### Technical Details:
*   **API Endpoint Removal:** The `createCloudDiskFile` API call has been removed from `src/RestApiClient.js`. This eliminates the ability to create cloud disk files through the API.
*   **Component Simplification:** The `File.vue` component no longer displays cloud disk-specific information. The `isCloudDisk` computed property and associated UI elements have been removed, simplifying the component's structure.
*   **Folder View Adjustments:** The `Folder.vue` component's "Add cloud disk" button and related dialog have been removed. The component's logic for determining cloud availability (`isCloudEnabled`) is also gone, streamlining the UI.