### PR TITLE
Adjust File Summary Card Appearance

### DIFF
--- a/src/components/FileSummary.vue
+++ b/src/components/FileSummary.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <template>
-  <v-card variant="flat" class="mt-4 ai-background-color">
+  <v-card variant="outlined" class="mt-4 custom-border-color">
     <v-toolbar color="transparent" density="compact">
       <v-toolbar-title style="font-size: 18px">
         <v-icon size="small" class="mr-2">mdi-shimmer</v-icon>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -14,21 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.ai-background-color {
-  background: linear-gradient(
-    90deg,
-    rgba(47, 79, 145, 0.1),
-    rgba(52, 92, 184, 0.1),
-    rgba(70, 109, 210, 0.1),
-    rgba(101, 132, 223, 0.1),
-    rgba(134, 158, 234, 0.1),
-    rgba(156, 147, 226, 0.1),
-    rgba(187, 159, 219, 0.1),
-    rgba(205, 171, 212, 0.1),
-    rgba(206, 182, 202, 0.1)
-  );
-}
-
 .custom-border-color {
     border: 1px solid rgb(var(--v-theme-custom-border-color));
 }

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -203,7 +203,7 @@ limitations under the License.
                 file.filesize < genAISizeLimit
               "
               variant="outlined"
-              class="text-none mt-4 custom-border-color ai-background-color"
+              class="text-none mt-4 custom-border-color"
               @click="generateFileSummary()"
             >
               <v-icon class="mr-2">mdi-shimmer</v-icon>


### PR DESCRIPTION
### Summary
Switched the `FileSummary` card and the "Generate Summary" button from a filled to an outlined style, and adjusted the background color.

### Technical Details:
*   **`FileSummary.vue` Modification:** Changed the `variant` property of the `<v-card>` component from `"flat"` to `"outlined"`.  This change alters the visual appearance of the file summary card, giving it an outlined style instead of a filled one.
*   **`File.vue` Modification:**  Removed the `ai-background-color` class from the "Generate Summary" button. This removes the background gradient from the button.
*   **`global.scss` Modification:** Removed the definition of the `ai-background-color` class.  This removes the background gradient styling that was previously applied to the components.  The `custom-border-color` class remains, providing a consistent border style.