### PR TITLE
Small improvement to error handling in UI 

### DIFF
--- a/src/stores/app.js
+++ b/src/stores/app.js
@@ -30,8 +30,13 @@ export const useAppStore = defineStore("app", {
     async setSystemConfig() {
       const response = await RestApiClient.getSystemConfig();
       this.systemConfig = await response;
-      const llmName =
-        localStorage.getItem("llm") || this.systemConfig.active_llms[0].name;
+      const llmNameLocalStorage = localStorage.getItem("llm");
+      const llmNameSystemConfig =  null;
+      if (this.systemConfig.active_llms.length > 0) {
+        llmNameSystemConfig =  this.systemConfig.active_llms[0].name;
+      }
+      const llmName = llmNameLocalStorage || llmNameSystemConfig;
+
       const llm = this.systemConfig.active_llms.filter(
         (llm) => llm.name === llmName
       )[0];


### PR DESCRIPTION
Improved error handling for specific server configurations that would cause UI errors.

For example when no cloud or llm are configured on the server and the /configs/system/ API endpoint returns:
```
{
  "active_llms": [],
  "allowed_data_types_preview": [
    "openrelik:hayabusa:html_report"
  ]
}
```
An empty active_llms list, and no active_cloud key/value.
