### PR TITLE
Workflow Name Generation and Folder Icons

### DIFF
--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -413,6 +413,23 @@ export default {
         });
     });
   },
+  async generateWorkflowName(workflow) {
+    return new Promise((resolve, reject) => {
+      RestApiClient.get(
+        "/folders/" +
+          workflow.folder.id +
+          "/workflows/" +
+          workflow.id +
+          "/generate_name/"
+      )
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
   async copyWorkflow(workflow) {
     return new Promise((resolve, reject) => {
       RestApiClient.post(

--- a/src/components/FolderList.vue
+++ b/src/components/FolderList.vue
@@ -71,7 +71,22 @@ limitations under the License.
           </router-link>
         </span>
         <span v-else>
-          <v-icon class="mr-3 mt-n1" color="info"> mdi-folder</v-icon>
+          <v-icon
+            v-if="item.workflows.length"
+            class="mr-3 mt-n1"
+            color="blue-grey"
+          >
+            mdi-folder-play</v-icon
+          >
+          <v-icon
+            v-else-if="item.user.id !== currentUser.id"
+            class="mr-3 mt-n1"
+            color="info"
+          >
+            mdi-folder-account</v-icon
+          >
+          <v-icon v-else class="mr-3 mt-n1" color="info"> mdi-folder</v-icon>
+
           <router-link
             style="text-decoration: none; color: inherit"
             :to="{ name: 'folder', params: { folderId: item.id } }"
@@ -86,8 +101,9 @@ limitations under the License.
         <span
           v-if="file.filesize || file.filesize === 0"
           :title="file.filesize"
-          >{{ $filters.formatBytes(file.filesize) }}</span
         >
+          {{ $filters.formatBytes(file.filesize) }}
+        </span>
       </template>
 
       <!-- Only show select box for files. -->
@@ -160,16 +176,16 @@ export default {
       headers: [
         { title: "Name", key: "display_name" },
         { title: "", key: "data-table-select" },
-        { title: "Created", key: "created_at" },
+        { title: "Owner", key: "user" },
+        { title: "Last modified", key: "updated_at" },
         { title: "Size", key: "filesize" },
         { title: "Type", key: "magic_mime" },
-        { title: "Owner", key: "user" },
         { title: "Actions", key: "actions", sortable: false, width: "140px" },
       ],
       homeViewHeaders: [
         { title: "Name", key: "display_name" },
-        { title: "Created", key: "created_at" },
         { title: "Owner", key: "user" },
+        { title: "Last modified", key: "updated_at" },
         { title: "Actions", key: "actions", sortable: false, width: "140px" },
       ],
     };

--- a/src/components/FolderList.vue
+++ b/src/components/FolderList.vue
@@ -85,7 +85,7 @@ limitations under the License.
           >
             mdi-folder-account</v-icon
           >
-          <v-icon v-else class="mr-3 mt-n1" color="info"> mdi-folder</v-icon>
+          <v-icon v-else class="mr-3 mt-n1" color="info">mdi-folder</v-icon>
 
           <router-link
             style="text-decoration: none; color: inherit"

--- a/src/components/Workflow.vue
+++ b/src/components/Workflow.vue
@@ -263,7 +263,7 @@ export default {
       // and if there are active LLMs configured.
       if (this.systemConfig.active_llms.length) {
         if (this.workflow.display_name === "Untitled workflow") {
-          this.workflow.display_name = "Generating workflow name..";
+          this.workflow.display_name = "Generating workflow name...";
           RestApiClient.generateWorkflowName(this.workflow).then((response) => {
             this.renameWorkflow(response.generated_name);
           });

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -311,7 +311,7 @@ limitations under the License.
     >
       mdi-folder-account</v-icon
     >
-    <v-icon v-else class="mr-3" color="info"> mdi-folder</v-icon>
+    <v-icon v-else class="mr-3" color="info">mdi-folder</v-icon>
 
     <v-hover v-if="!folder.is_deleted" v-slot="{ isHovering, props }">
       <h2 v-bind="props" @dblclick="showRenameFolderDialog = true">

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -45,6 +45,7 @@ limitations under the License.
       </div>
     </v-card>
   </v-dialog>
+
   <!-- Rename folder dialog -->
   <v-dialog v-model="showRenameFolderDialog" width="400">
     <v-card width="400" class="mx-auto">
@@ -79,6 +80,7 @@ limitations under the License.
       </div>
     </v-card>
   </v-dialog>
+
   <!-- Upload files dialog -->
   <v-dialog v-model="showUpload" width="800" persistent>
     <v-card width="800" class="mx-auto">
@@ -295,7 +297,22 @@ limitations under the License.
 
   <!-- Folder -->
   <span style="display: flex; align-items: center">
-    <v-icon class="mr-3" color="info">mdi-folder</v-icon>
+    <v-icon
+      v-if="folder.workflows && folder.workflows.length"
+      class="mr-3"
+      color="blue-grey"
+    >
+      mdi-folder-play</v-icon
+    >
+    <v-icon
+      v-else-if="folder.user && folder.user.id !== currentUser.id"
+      class="mr-3"
+      color="info"
+    >
+      mdi-folder-account</v-icon
+    >
+    <v-icon v-else class="mr-3" color="info"> mdi-folder</v-icon>
+
     <v-hover v-if="!folder.is_deleted" v-slot="{ isHovering, props }">
       <h2 v-bind="props" @dblclick="showRenameFolderDialog = true">
         {{ folder.display_name }}
@@ -402,7 +419,7 @@ limitations under the License.
         :show-controls="true"
         @workflow-updated="refreshFileListing()"
         @workflow-deleted="deleteWorkflow()"
-        @workflow-renamed="renameFolder($event)"
+        @workflow-renamed="renameFolderFromWorkflow($event)"
       >
       </workflow>
 
@@ -429,6 +446,7 @@ limitations under the License.
 
 <script>
 import RestApiClient from "@/RestApiClient";
+import { useUserStore } from "@/stores/user";
 import { useAppStore } from "@/stores/app";
 import FolderList from "@/components/FolderList";
 import UploadFile from "@/components/UploadFile";
@@ -467,6 +485,7 @@ export default {
       isLoading: false,
       no_access: false,
       appStore: useAppStore(),
+      userStore: useUserStore(),
       selectedUsers: [],
       selectedUsersRole: "Editor",
       selectedGroups: [],
@@ -477,6 +496,9 @@ export default {
   computed: {
     systemConfig() {
       return this.appStore.systemConfig;
+    },
+    currentUser() {
+      return this.userStore.user;
     },
     items() {
       return this.folders.concat(this.files);
@@ -536,6 +558,14 @@ export default {
         this.showRenameFolderDialog = false;
       });
     },
+    renameFolderFromWorkflow(newName) {
+      // Only rename the folder if it is untitled
+      if (this.folder.display_name === "Untitled workflow") {
+        this.renameFolder(newName);
+        return;
+      }
+      return;
+    },
     shareFolder() {
       RestApiClient.shareFolder(
         this.folder.id,
@@ -594,8 +624,8 @@ export default {
           }
         });
     },
-    getMyFolderRole(folderID) {
-      RestApiClient.getMyFolderRole(this.folderId).then((response) => {
+    getMyFolderRole(folderId) {
+      RestApiClient.getMyFolderRole(folderId).then((response) => {
         this.myRole = response;
       });
     },


### PR DESCRIPTION
### Technical Details:
*   **Workflow Name Generation:**
    *   Introduces a new API endpoint (`/folders/{folderId}/workflows/{workflowId}/generate_name/`) in `RestApiClient.js` to generate a workflow name based on folder and workflow context, when LLMs are configured.
    *   In `Workflow.vue`, when running a workflow with the default "Untitled workflow" name and if active LLMs are configured, the system now calls the new API to generate a name. The UI updates the workflow name to "Generating workflow name..." and then renames the workflow once a new name is obtained.
*   **Folder Icons:**
    *   Modifies folder icons in `FolderList.vue` and `Folder.vue` to distinguish between regular folders, folders with workflows (indicated by `mdi-folder-play`), and shared folders (indicated by `mdi-folder-account`).
    *   File list headers in `FolderList.vue` are reordered to place `Owner` and `Last modified` ahead of `Size` and `Type`.
*   **Workflow Rename:**
    *   Updates the `renameWorkflow` function in `Workflow.vue` to take the new workflow name as an argument for more direct updating.
    *   Adds a check in `Folder.vue` within the `renameFolderFromWorkflow` function, to rename the parent folder automatically, but only if the folder name is the default "Untitled workflow" to avoid unintended renames.