### PR TITLE
AutoFormat RangeChart X-Axis Labels

### DIFF
--- a/src/components/RangeChart.vue
+++ b/src/components/RangeChart.vue
@@ -87,9 +87,6 @@ export default {
         },
         xaxis: {
           type: "datetime",
-          labels: {
-            format: "HH:mm:ss",
-          },
         },
         yaxis: {
           decimalsInFloat: false,


### PR DESCRIPTION
### Summary:
Removed unnecessary formatting from the RangeChart's X-axis labels.

### Technical Details:
*   The `labels.format` option was removed from the `xaxis` configuration in `src/components/RangeChart.vue`. The chart will now use the default datetime formatting, simplifying the visual display. This change reduces visual clutter and relies on the charting library's built-in intelligence for time-based label rendering.