### PR TITLE
Improve text file type detection

### DIFF
--- a/src/components/FileSummary.vue
+++ b/src/components/FileSummary.vue
@@ -41,7 +41,7 @@ limitations under the License.
         showSummary ? "mdi-chevron-down" : "mdi-chevron-right"
       }}</v-icon>
       <div class="ml-2" style="font-size: 18px">Summary</div>
-      <small class="ml-3 mt-2" style="font-size: 0.7em"
+      <small class="ml-3 mt-1" style="font-size: 0.7em"
         >(AI can make mistakes so always double-check)</small
       >
 

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -396,15 +396,16 @@ export default {
     },
     isTextFormat() {
       const textFileTypes = [
-        "text/plain",
-        "text/html",
         "application/json",
-        "text/csv",
         "application/javascript",
         "application/x-ndjson",
-        "text/x-diff",
       ];
-      return textFileTypes.includes(this.file.magic_mime);
+
+      // Check if magic_mime starts with "text/" or is included in the specific application file types
+      return (
+        this.file.magic_mime.startsWith("text/") ||
+        textFileTypes.includes(this.file.magic_mime)
+      );
     },
     allowedPreview() {
       // Render unescaped HTML content in sandboxed iframe if data_type is in server side


### PR DESCRIPTION
### Summary
Improved text file type detection by checking if the MIME type starts with "text/".

### Technical Details:
*   **`File.vue` Modification:** The `isTextFormat` computed property in `src/views/File.vue` is changed to determine if a file is a text file.  Instead of relying on a pre-defined list of `magic_mime` types it now checks if the `magic_mime` property starts with `text/`. The original list of specific `application` mime types is still included as a condition.
*   **Justification:** This change broadens the scope of text file detection. Previously only files matching a specific list of `magic_mime` types were identified as text files. This update now recognizes *any* file with a MIME type starting with "text/" as a text file, alongside the explicitly listed application types. This prevents misclassification of text-based files with less common or more specific MIME types, improving user experience.
*   **Styling Fix:**  Corrects minor vertical alignment in `FileSummary.vue` to adjust the spacing of an informational message, improving readability.