### PR TITLE
Update WorkflowTreeNode.vue

### DIFF
--- a/src/components/WorkflowTreeNode.vue
+++ b/src/components/WorkflowTreeNode.vue
@@ -122,7 +122,7 @@ limitations under the License.
             "
           >
             <small class="ml-1 red-text">
-              <strong>{{ hasHighPriorityReports.length }}</strong> report(s)
+              <strong>{{ hasHighPriorityFileReports.length }}</strong> report(s)
               with high priority findings
             </small>
           </div>


### PR DESCRIPTION
hasHighPriorityReport was renamed to hasHighPriorityFileReport. Template still used the old name and this triggered a UI bug that "crashed" the workflow tree from building. 