### PR TITLE
Move theme toggle to System Menu and remove workflow tab

### DIFF
--- a/src/components/ProfileMenu.vue
+++ b/src/components/ProfileMenu.vue
@@ -118,7 +118,6 @@ limitations under the License.
       <profile-picture :user="user" :size="size" v-bind="props" />
     </template>
     <v-list width="200">
-      <toggle-theme />
       <v-list-item @click="showApiKeysDialog = !showApiKeysDialog">
         <template v-slot:prepend>
           <v-icon size="small">mdi-key-outline</v-icon>
@@ -141,7 +140,6 @@ import RestApiClient from "@/RestApiClient";
 import settings from "@/settings";
 import { useUserStore } from "@/stores/user";
 import ProfilePicture from "./ProfilePicture.vue";
-import ToggleTheme from "./ToggleTheme.vue";
 
 export default {
   props: {
@@ -149,7 +147,6 @@ export default {
   },
   components: {
     ProfilePicture,
-    ToggleTheme,
   },
   data() {
     return {

--- a/src/components/SystemMenu.vue
+++ b/src/components/SystemMenu.vue
@@ -19,6 +19,7 @@ limitations under the License.
       <v-icon v-bind="props" class="ml-3">mdi-dots-vertical</v-icon>
     </template>
     <v-list width="200">
+      <toggle-theme />
       <v-list-item :to="'/metrics'">
         <template v-slot:prepend>
           <v-icon size="small">mdi-chart-box</v-icon>
@@ -31,12 +32,16 @@ limitations under the License.
 
 <script>
 import { useTheme } from "vuetify";
+import ToggleTheme from "./ToggleTheme.vue";
 
 export default {
   data() {
     return {
       theme: useTheme(),
     };
+  },
+  components: {
+    ToggleTheme,
   },
   methods: {
     toggleTheme() {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -91,12 +91,6 @@ const routes = [
             component: File,
             props: true,
           },
-          {
-            path: "file/:fileId/workflows",
-            name: "fileWorkflows",
-            component: File,
-            props: true,
-          },
         ],
       },
     ],

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -279,47 +279,6 @@ limitations under the License.
               </v-table>
             </v-card>
           </v-tabs-window-item>
-
-          <!-- Workflows -->
-          <v-tabs-window-item
-            :value="2"
-            :transition="false"
-            :reverse-transition="false"
-          >
-            <v-card
-              v-if="!file.workflows.length"
-              variant="flat"
-              color="transparent"
-            >
-              <div
-                style="font-family: monospace; font-size: 0.9em"
-                class="ml-4"
-              >
-                <strong>
-                  This file hasn't been used as input to any workflows yet.
-                </strong>
-                <br />
-                <span v-if="canEdit">
-                  Let's
-                  <span
-                    style="text-decoration: underline; cursor: pointer"
-                    @click="createWorkflow()"
-                    >create a workflow</span
-                  >
-                  to get started.
-                </span>
-              </div>
-            </v-card>
-
-            <span style="font-family: monospace"></span>
-            <workflow
-              v-for="workflow in file.workflows"
-              :key="workflow.id"
-              :initial-workflow="workflow"
-              :show-controls="false"
-              class="mt-4"
-            ></workflow>
-          </v-tabs-window-item>
         </v-tabs-window>
       </div>
     </div>
@@ -362,7 +321,6 @@ export default {
       fileContent: null,
       showFilePreview: true,
       fileContentLoading: false,
-      workflows: [],
       fileSizeLimit: 10485760,
       genAISizeLimit: 2097152,
       activeTab: null,
@@ -380,12 +338,6 @@ export default {
           value: "1",
           routeName: "fileDetails",
           route: "details",
-        },
-        {
-          name: "Workflows",
-          value: "2",
-          routeName: "fileWorkflows",
-          route: "workflows",
         },
       ],
     };


### PR DESCRIPTION
### Summary
Moves the theme toggle from the Profile Menu to the System Menu and removes the workflow tab from the File view.

### Technical Details:
*   **Component Relocation:** The `ToggleTheme` component was moved from `ProfileMenu.vue` to `SystemMenu.vue`. This groups system-wide settings together.
*   **Menu Structure Adjustment:** The theme toggle is now accessible within the System Menu.
*   **Route Modification:** The `file/:fileId/workflows` route has been removed from `src/router/index.js`. This suggests that the workflow functionality is being removed or relocated.
*   **UI Simplification:** The workflow tab has been removed from the `File.vue` component. The associated logic and UI elements are no longer present.