### PR TITLE
Remove unused resumable.js browser assignment

### DIFF
--- a/src/components/UploadFile.vue
+++ b/src/components/UploadFile.vue
@@ -177,8 +177,6 @@ export default {
         message: JSON.parse(message),
       });
     });
-
-    this.resumable.assignBrowse(this.$refs.fileInput.$el);
   },
   methods: {
     uploadFiles() {


### PR DESCRIPTION
### Summary
Removes an unnecessary `resumable.assignBrowse` call that was causing issues.

### Technical Details:
*   The line `this.resumable.assignBrowse(this.$refs.fileInput.$el);` in `src/components/UploadFile.vue` has been removed. This line was attempting to assign the browse functionality of resumable.js to a specific element, but it was no longer needed and was causing unexpected behavior. Removing it resolves the issue with file dialogue appearing multipe times due to multipl click events.