### PR TITLE
Freeze lockfile on install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package.json ./
 COPY yarn.lock ./
 # Install the project dependencies
-RUN yarn install
+RUN yarn install --frozen-lockfile
 # Copy the rest of the project files to the container
 COPY . .
 # Build the Vue.js application to the production mode to dist folder


### PR DESCRIPTION
Freeze the lock file on yarn install to prevent yarn updating the npm dependencies on a build when the packages.json and yarn.lockfile are out of sync. This is to make sure we do NOT automatically update packages on a build.