### PR TITLE
feat: UI for external read-only datastores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ pnpm-debug.log*
 
 # Test coverage reports from V8
 coverage
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ pnpm-debug.log*
 
 # Test coverage reports from V8
 coverage
-CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The UI supports registering files from external read-only storage locations dire
 
 A settings dialog for managing external storage configurations. Accessible from the system menu. Provides full CRUD operations:
 
-- Lists all configured external storages with their name, type, and base path.
-- Create a new storage configuration (name, type, connection details).
-- Edit an existing configuration inline.
+- Lists all configured external storages with their name, mount point, and description.
+- Create a new storage configuration (name, mount point, and description).
+- Edit an existing configuration inline — only mount point and description can be changed. **Storage name is immutable after creation**; to rename, delete and recreate the entry.
 - Delete a configuration (with confirmation).
 - The mount point field displays a hint clarifying that the value must match the container path defined in `docker-compose.yml`.
 - After creating or updating a storage, the UI probes it via the browse endpoint and shows a success message if accessible, or a warning if the mount point cannot be reached (e.g. missing volume mount or container not restarted).
@@ -56,11 +56,11 @@ Added an "External storages" menu item that opens the `ExternalStorageManager` d
 
 **`FolderList.vue`**
 
-- External files are visually distinguished with an "external" badge. Edit and delete actions are disabled for external file entries.
+- External files are visually distinguished with an "external" badge. The delete button is hidden for external file entries. External files are selectable for bulk workflow creation — workers read them directly from the mounted path.
 - Virtual external folders (synthetic entries representing subdirectories within a mounted storage) are rendered with a network folder icon (`mdi-folder-network-outline`) and emit navigation events instead of routing to a real folder URL.
 - The ".." entry navigates up within the virtual path when inside a virtual external subdirectory, rather than routing to the parent real folder.
 - Virtual folders show "—" in the Last modified column instead of an invalid date.
 
 **`File.vue`**
 
-The Details tab for external files includes a storage metadata section showing the originating storage name, type, and path. The "Create workflow" action is disabled for external files, as they are read-only references and cannot be used as workflow inputs.
+The Details tab for external files includes a storage metadata section showing the originating storage name and path. The "Create workflow" action is available for external files — workers read them directly from the mounted path, so they are valid workflow inputs.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,25 @@ A settings dialog for managing external storage configurations. Accessible from 
 - Create a new storage configuration (name, type, connection details).
 - Edit an existing configuration inline.
 - Delete a configuration (with confirmation).
+- The mount point field displays a hint clarifying that the value must match the container path defined in `docker-compose.yml`.
+- After creating or updating a storage, the UI probes it via the browse endpoint and shows a success message if accessible, or a warning if the mount point cannot be reached (e.g. missing volume mount or container not restarted).
 
 **`AddExternalFileDialog.vue`**
 
-A file browser dialog for navigating a selected external storage and registering files into the current folder. Opened from the folder view. Allows users to:
+A file browser dialog for navigating a selected external storage and registering individual files into the current folder. Opened from the folder view. Allows users to:
 
 - Select an external storage backend from those configured in `ExternalStorageManager`.
-- Browse the directory tree of that storage.
-- Select one or more files to register; on confirmation the files are added to the folder as external references.
+- Browse the directory tree interactively — the storage root loads automatically on selection; directories and files are shown with icons.
+- Breadcrumb navigation within the storage; the storage name is shown as the root segment (e.g. `case_storage → evidence`).
+- Click a file to select it, then confirm to register it as an external reference in the folder.
+
+**`MountExternalStorageDialog.vue`**
+
+A dialog for mounting an external storage directly to a folder, so that all files under a given path within that storage are automatically synced into the folder's file list. Opened from the folder toolbar. Allows users to:
+
+- Select an external storage backend from the configured list.
+- Optionally specify a base path within the storage to use as the root (defaults to the storage root).
+- On confirmation, the folder is updated via `PATCH /api/v1/folders/{id}` and the file list refreshes immediately.
 
 ### Modified Components
 
@@ -38,11 +49,17 @@ Added an "External storages" menu item that opens the `ExternalStorageManager` d
 
 **`Folder.vue`**
 
-Added an "Add from external storage" button in the folder toolbar that opens the `AddExternalFileDialog`.
+- Added an "Add from external storage" button that opens `AddExternalFileDialog` for registering individual files.
+- Added a "Mount external storage" button that opens `MountExternalStorageDialog` for folder-level mounts.
+- When a folder has an external storage mounted, a chip displaying the storage name appears next to the folder title. The chip has an × button that unmounts the storage (`PATCH` with `null` values) and refreshes the file list.
+- Files auto-synced from a mounted storage that reside in subdirectories are grouped into virtual folders in the file list. Clicking a virtual folder navigates into it, showing only the files at that level. A breadcrumb strip above the list displays the current virtual path with the storage name as root (e.g. `case_storage → evidence`); each segment is clickable for direct navigation. The virtual path resets when navigating to a different real folder.
 
 **`FolderList.vue`**
 
-External files are visually distinguished with an "external" badge. Edit and delete actions are disabled for external file entries, since the source data is not managed by OpenRelik.
+- External files are visually distinguished with an "external" badge. Edit and delete actions are disabled for external file entries.
+- Virtual external folders (synthetic entries representing subdirectories within a mounted storage) are rendered with a network folder icon (`mdi-folder-network-outline`) and emit navigation events instead of routing to a real folder URL.
+- The ".." entry navigates up within the virtual path when inside a virtual external subdirectory, rather than routing to the parent real folder.
+- Virtual folders show "—" in the Last modified column instead of an invalid date.
 
 **`File.vue`**
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,48 @@
 
 ##### Obligatory Fine Print
 This is not an official Google product (experimental or otherwise), it is just code that happens to be owned by Google.
+
+---
+
+## External Read-Only Data Stores
+
+### Overview
+
+The UI supports registering files from external read-only storage locations directly into folders without copying the underlying data. Administrators configure named storage backends (e.g. network shares, object stores) once; users can then browse those locations and register individual files into any folder. Registered external files are treated as read-only references: their metadata is stored in OpenRelik, but the bytes remain in place on the external storage.
+
+### New Components
+
+**`ExternalStorageManager.vue`**
+
+A settings dialog for managing external storage configurations. Accessible from the system menu. Provides full CRUD operations:
+
+- Lists all configured external storages with their name, type, and base path.
+- Create a new storage configuration (name, type, connection details).
+- Edit an existing configuration inline.
+- Delete a configuration (with confirmation).
+
+**`AddExternalFileDialog.vue`**
+
+A file browser dialog for navigating a selected external storage and registering files into the current folder. Opened from the folder view. Allows users to:
+
+- Select an external storage backend from those configured in `ExternalStorageManager`.
+- Browse the directory tree of that storage.
+- Select one or more files to register; on confirmation the files are added to the folder as external references.
+
+### Modified Components
+
+**`SystemMenu.vue`**
+
+Added an "External storages" menu item that opens the `ExternalStorageManager` dialog.
+
+**`Folder.vue`**
+
+Added an "Add from external storage" button in the folder toolbar that opens the `AddExternalFileDialog`.
+
+**`FolderList.vue`**
+
+External files are visually distinguished with an "external" badge. Edit and delete actions are disabled for external file entries, since the source data is not managed by OpenRelik.
+
+**`File.vue`**
+
+The Details tab for external files includes a storage metadata section showing the originating storage name, type, and path. The "Create workflow" action is disabled for external files, as they are read-only references and cannot be used as workflow inputs.

--- a/src/RestApiClient.js
+++ b/src/RestApiClient.js
@@ -836,4 +836,80 @@ export default {
         });
     });
   },
+  async getDatastores() {
+    return new Promise((resolve, reject) => {
+      RestApiClient.get("/datastores/")
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+  async createDatastore(name, mountPoint, description) {
+    const requestBody = { name, mount_point: mountPoint, description };
+    return new Promise((resolve, reject) => {
+      RestApiClient.post("/datastores/", requestBody)
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+  async updateDatastore(name, requestBody) {
+    return new Promise((resolve, reject) => {
+      RestApiClient.patch("/datastores/" + name, requestBody)
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+  async deleteDatastore(name) {
+    return new Promise((resolve, reject) => {
+      RestApiClient.delete("/datastores/" + name)
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+  async browseDatastore(name, path = "") {
+    return new Promise((resolve, reject) => {
+      RestApiClient.get("/datastores/" + name + "/browse", { params: { path } })
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
+  async registerExternalFile(
+    datastoreName,
+    folderId,
+    relativePath,
+    displayName,
+    extension,
+  ) {
+    const requestBody = { folder_id: folderId, relative_path: relativePath };
+    if (displayName) requestBody.display_name = displayName;
+    if (extension) requestBody.extension = extension;
+    return new Promise((resolve, reject) => {
+      RestApiClient.post("/datastores/" + datastoreName + "/files", requestBody)
+        .then((response) => {
+          resolve(response.data);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  },
 };

--- a/src/components/AddExternalFileDialog.vue
+++ b/src/components/AddExternalFileDialog.vue
@@ -55,7 +55,7 @@ limitations under the License.
                 :class="{ 'text-primary': true }"
                 style="cursor: pointer"
                 @click="browseTo('')"
-              >root</span>
+              >{{ form.datastoreName }}</span>
               <template v-for="(segment, index) in breadcrumbSegments" :key="index">
                 <v-icon size="x-small" class="mx-1">mdi-chevron-right</v-icon>
                 <span

--- a/src/components/AddExternalFileDialog.vue
+++ b/src/components/AddExternalFileDialog.vue
@@ -42,6 +42,12 @@ limitations under the License.
             hide-details
             @update:model-value="onDatastoreSelected"
           />
+          <div
+            v-if="datastores.length === 0 && !isLoadingDatastores"
+            class="text-caption text-medium-emphasis mb-3"
+          >
+            No external storages configured. Add one via Settings → External Storages.
+          </div>
 
           <!-- File browser -->
           <div
@@ -163,6 +169,7 @@ export default {
     return {
       dialog: false,
       datastores: [],
+      isLoadingDatastores: false,
       errorMessage: "",
       isSubmitting: false,
       browserItems: [],
@@ -200,12 +207,16 @@ export default {
         displayName: "",
         extension: "",
       };
+      this.isLoadingDatastores = true;
       RestApiClient.getDatastores()
         .then((data) => {
           this.datastores = data;
         })
         .catch(() => {
           this.errorMessage = "Failed to load datastores.";
+        })
+        .finally(() => {
+          this.isLoadingDatastores = false;
         });
     },
     onDatastoreSelected() {

--- a/src/components/AddExternalFileDialog.vue
+++ b/src/components/AddExternalFileDialog.vue
@@ -1,0 +1,304 @@
+<!--
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <v-dialog v-model="dialog" width="650">
+    <v-card>
+      <v-card-title>Add from external storage</v-card-title>
+      <div class="pa-4">
+        <v-alert
+          v-if="errorMessage"
+          type="error"
+          variant="tonal"
+          density="compact"
+          closable
+          class="mb-4"
+          @click:close="errorMessage = ''"
+          >{{ errorMessage }}</v-alert
+        >
+
+        <v-form @submit.prevent @keyup.enter="submit()">
+          <v-select
+            v-model="form.datastoreName"
+            :items="datastores"
+            item-title="name"
+            item-value="name"
+            label="External storage *"
+            variant="outlined"
+            density="compact"
+            class="mb-3"
+            hide-details
+            @update:model-value="onDatastoreSelected"
+          />
+
+          <!-- File browser -->
+          <div
+            v-if="form.datastoreName"
+            class="browser-container mb-3"
+          >
+            <!-- Breadcrumbs -->
+            <div class="browser-breadcrumbs d-flex align-center flex-wrap pa-2">
+              <span
+                class="breadcrumb-item text-caption"
+                :class="{ 'text-primary': true }"
+                style="cursor: pointer"
+                @click="browseTo('')"
+              >root</span>
+              <template v-for="(segment, index) in breadcrumbSegments" :key="index">
+                <v-icon size="x-small" class="mx-1">mdi-chevron-right</v-icon>
+                <span
+                  class="breadcrumb-item text-caption"
+                  :class="index === breadcrumbSegments.length - 1 ? 'text-medium-emphasis' : 'text-primary'"
+                  :style="index < breadcrumbSegments.length - 1 ? 'cursor: pointer' : ''"
+                  @click="index < breadcrumbSegments.length - 1 && browseTo(segment.path)"
+                >{{ segment.name }}</span>
+              </template>
+            </div>
+
+            <v-divider />
+
+            <!-- Item list -->
+            <div class="browser-list" style="min-height: 200px; max-height: 280px; overflow-y: auto">
+              <div
+                v-if="browserLoading"
+                class="d-flex justify-center align-center"
+                style="height: 200px"
+              >
+                <v-progress-circular indeterminate size="24" />
+              </div>
+              <div
+                v-else-if="browserError"
+                class="pa-3 text-caption text-error"
+              >{{ browserError }}</div>
+              <div
+                v-else-if="browserItems.length === 0"
+                class="pa-3 text-caption text-medium-emphasis"
+              >Empty directory</div>
+              <v-list v-else density="compact" class="pa-0">
+                <v-list-item
+                  v-for="item in browserItems"
+                  :key="item.name"
+                  :class="[
+                    'browser-item',
+                    item.type === 'file' && selectedFile && selectedFile.name === item.name && selectedFile.path === resolvedItemPath(item)
+                      ? 'browser-item--selected'
+                      : ''
+                  ]"
+                  :title="item.name"
+                  :subtitle="item.type === 'file' && item.size !== null ? formatBytes(item.size) : undefined"
+                  :prepend-icon="item.type === 'directory' ? 'mdi-folder' : 'mdi-file-outline'"
+                  :prepend-icon-color="item.type === 'directory' ? 'info' : undefined"
+                  style="cursor: pointer"
+                  @click="onItemClick(item)"
+                />
+              </v-list>
+            </div>
+          </div>
+
+          <div v-if="selectedFile" class="text-caption text-medium-emphasis mb-3">
+            Selected: <strong>{{ selectedFile.path }}</strong>
+          </div>
+
+          <v-text-field
+            v-model="form.displayName"
+            label="Display name (optional)"
+            variant="outlined"
+            density="compact"
+            class="mb-3"
+            hide-details
+          />
+          <v-text-field
+            v-model="form.extension"
+            label="Extension (optional)"
+            variant="outlined"
+            density="compact"
+            class="mb-4"
+            hide-details
+            placeholder="e.g. .img"
+          />
+        </v-form>
+
+        <v-btn
+          variant="flat"
+          color="primary"
+          class="text-none mr-2"
+          :disabled="!form.datastoreName || !selectedFile || isSubmitting"
+          :loading="isSubmitting"
+          @click="submit()"
+          >Add file</v-btn
+        >
+        <v-btn variant="text" class="text-none" @click="dialog = false"
+          >Cancel</v-btn
+        >
+      </div>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import RestApiClient from "@/RestApiClient";
+
+export default {
+  name: "AddExternalFileDialog",
+  props: {
+    folderId: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ["file-added"],
+  data() {
+    return {
+      dialog: false,
+      datastores: [],
+      errorMessage: "",
+      isSubmitting: false,
+      browserItems: [],
+      browserPath: "",
+      browserLoading: false,
+      browserError: "",
+      selectedFile: null,
+      form: {
+        datastoreName: null,
+        displayName: "",
+        extension: "",
+      },
+    };
+  },
+  computed: {
+    breadcrumbSegments() {
+      if (!this.browserPath) return [];
+      const parts = this.browserPath.split("/").filter(Boolean);
+      return parts.map((name, index) => ({
+        name,
+        path: parts.slice(0, index + 1).join("/"),
+      }));
+    },
+  },
+  methods: {
+    open() {
+      this.dialog = true;
+      this.errorMessage = "";
+      this.browserItems = [];
+      this.browserPath = "";
+      this.browserError = "";
+      this.selectedFile = null;
+      this.form = {
+        datastoreName: null,
+        displayName: "",
+        extension: "",
+      };
+      RestApiClient.getDatastores()
+        .then((data) => {
+          this.datastores = data;
+        })
+        .catch(() => {
+          this.errorMessage = "Failed to load datastores.";
+        });
+    },
+    onDatastoreSelected() {
+      this.browserPath = "";
+      this.browserItems = [];
+      this.browserError = "";
+      this.selectedFile = null;
+      this.browseTo("");
+    },
+    browseTo(path) {
+      this.browserPath = path;
+      this.browserLoading = true;
+      this.browserError = "";
+      this.selectedFile = null;
+      RestApiClient.browseDatastore(this.form.datastoreName, path)
+        .then((data) => {
+          this.browserPath = data.current_path || path;
+          this.browserItems = data.items || [];
+        })
+        .catch(() => {
+          this.browserError = "Failed to load directory contents.";
+          this.browserItems = [];
+        })
+        .finally(() => {
+          this.browserLoading = false;
+        });
+    },
+    resolvedItemPath(item) {
+      return this.browserPath ? this.browserPath + "/" + item.name : item.name;
+    },
+    onItemClick(item) {
+      if (item.type === "directory") {
+        this.browseTo(this.resolvedItemPath(item));
+      } else {
+        const filePath = this.resolvedItemPath(item);
+        this.selectedFile = { name: item.name, path: filePath, size: item.size };
+      }
+    },
+    formatBytes(bytes) {
+      if (bytes === 0) return "0 B";
+      const k = 1024;
+      const sizes = ["B", "KB", "MB", "GB", "TB"];
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+      return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+    },
+    submit() {
+      if (!this.form.datastoreName || !this.selectedFile) return;
+      this.isSubmitting = true;
+      this.errorMessage = "";
+      RestApiClient.registerExternalFile(
+        this.form.datastoreName,
+        this.folderId,
+        this.selectedFile.path,
+        this.form.displayName || undefined,
+        this.form.extension || undefined,
+      )
+        .then((file) => {
+          this.$emit("file-added", file);
+          this.dialog = false;
+        })
+        .catch((err) => {
+          const status = err?.response?.status;
+          const detail = err?.response?.data?.detail;
+          if (status === 404) {
+            this.errorMessage = `File not found at path "${this.selectedFile.path}" in the selected storage.`;
+          } else if (status === 400) {
+            this.errorMessage =
+              detail ||
+              "Invalid path (check for directory traversal or directory paths).";
+          } else {
+            this.errorMessage = detail || "Failed to register external file.";
+          }
+        })
+        .finally(() => {
+          this.isSubmitting = false;
+        });
+    },
+  },
+  expose: ["open"],
+};
+</script>
+
+<style scoped>
+.browser-container {
+  border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
+  border-radius: 4px;
+}
+
+.browser-breadcrumbs {
+  background-color: rgba(var(--v-theme-surface-variant), 0.4);
+}
+
+.browser-item--selected {
+  background-color: rgba(var(--v-theme-primary), 0.12);
+}
+</style>

--- a/src/components/ExternalStorageManager.vue
+++ b/src/components/ExternalStorageManager.vue
@@ -43,6 +43,28 @@ limitations under the License.
         >{{ errorMessage }}</v-alert
       >
 
+      <v-alert
+        v-if="successMessage"
+        type="success"
+        variant="tonal"
+        density="compact"
+        closable
+        class="ma-4"
+        @click:close="successMessage = ''"
+        >{{ successMessage }}</v-alert
+      >
+
+      <v-alert
+        v-if="warningMessage"
+        type="warning"
+        variant="tonal"
+        density="compact"
+        closable
+        class="ma-4"
+        @click:close="warningMessage = ''"
+        >{{ warningMessage }}</v-alert
+      >
+
       <!-- Create form -->
       <v-expand-transition>
         <div v-if="showCreateForm" class="pa-4 pb-0">
@@ -76,6 +98,9 @@ limitations under the License.
                 />
               </v-col>
             </v-row>
+            <div class="text-caption text-medium-emphasis mt-2">
+              Mount point must match the container path defined in docker-compose.yml (e.g. /mnt/external)
+            </div>
             <div class="mt-3">
               <v-btn
                 variant="flat"
@@ -195,6 +220,8 @@ export default {
       datastores: [],
       isLoading: false,
       errorMessage: "",
+      successMessage: "",
+      warningMessage: "",
       showCreateForm: false,
       createForm: { name: "", mountPoint: "", description: "" },
       editingName: null,
@@ -204,6 +231,9 @@ export default {
   methods: {
     open() {
       this.dialog = true;
+      this.errorMessage = "";
+      this.successMessage = "";
+      this.warningMessage = "";
       this.loadDatastores();
     },
     loadDatastores() {
@@ -222,6 +252,17 @@ export default {
     resetCreateForm() {
       this.createForm = { name: "", mountPoint: "", description: "" };
     },
+    probeDatastore(name, mountPoint) {
+      RestApiClient.browseDatastore(name, "")
+        .then(() => {
+          this.successMessage = `Storage '${name}' created and accessible.`;
+        })
+        .catch(() => {
+          this.warningMessage =
+            `Storage created, but mount point ${mountPoint} is not accessible. ` +
+            `Make sure the path is mounted in docker-compose.yml and the container is restarted.`;
+        });
+    },
     createDatastore() {
       const { name, mountPoint, description } = this.createForm;
       RestApiClient.createDatastore(name, mountPoint, description)
@@ -229,6 +270,7 @@ export default {
           this.datastores.push(ds);
           this.showCreateForm = false;
           this.resetCreateForm();
+          this.probeDatastore(ds.name, ds.mount_point);
         })
         .catch((err) => {
           this.errorMessage =
@@ -252,6 +294,7 @@ export default {
           const idx = this.datastores.findIndex((d) => d.name === name);
           if (idx !== -1) this.datastores[idx] = updated;
           this.editingName = null;
+          this.probeDatastore(updated.name, updated.mount_point);
         })
         .catch((err) => {
           this.errorMessage =

--- a/src/components/ExternalStorageManager.vue
+++ b/src/components/ExternalStorageManager.vue
@@ -1,0 +1,280 @@
+<!--
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <v-dialog v-model="dialog" width="700">
+    <v-card>
+      <v-toolbar color="transparent" density="compact">
+        <v-btn icon variant="flat" @click="dialog = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+        <v-toolbar-title>External storages</v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          variant="text"
+          class="text-none mr-2"
+          prepend-icon="mdi-plus"
+          @click="showCreateForm = !showCreateForm"
+          >Add storage</v-btn
+        >
+      </v-toolbar>
+      <v-divider />
+
+      <v-alert
+        v-if="errorMessage"
+        type="error"
+        variant="tonal"
+        density="compact"
+        closable
+        class="ma-4"
+        @click:close="errorMessage = ''"
+        >{{ errorMessage }}</v-alert
+      >
+
+      <!-- Create form -->
+      <v-expand-transition>
+        <div v-if="showCreateForm" class="pa-4 pb-0">
+          <v-card variant="outlined" class="pa-4 mb-2">
+            <v-row dense>
+              <v-col cols="4">
+                <v-text-field
+                  v-model="createForm.name"
+                  label="Name *"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                />
+              </v-col>
+              <v-col cols="4">
+                <v-text-field
+                  v-model="createForm.mountPoint"
+                  label="Mount point *"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                />
+              </v-col>
+              <v-col cols="4">
+                <v-text-field
+                  v-model="createForm.description"
+                  label="Description"
+                  variant="outlined"
+                  density="compact"
+                  hide-details
+                />
+              </v-col>
+            </v-row>
+            <div class="mt-3">
+              <v-btn
+                variant="flat"
+                color="primary"
+                class="text-none mr-2"
+                :disabled="!createForm.name || !createForm.mountPoint"
+                @click="createDatastore()"
+                >Create</v-btn
+              >
+              <v-btn
+                variant="text"
+                class="text-none"
+                @click="showCreateForm = false; resetCreateForm()"
+                >Cancel</v-btn
+              >
+            </div>
+          </v-card>
+        </div>
+      </v-expand-transition>
+
+      <!-- Datastores table -->
+      <v-table density="compact" class="ma-4">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Mount point</th>
+            <th>Description</th>
+            <th style="width: 96px">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="isLoading">
+            <td colspan="4" class="text-center py-4">Loading...</td>
+          </tr>
+          <tr v-else-if="!datastores.length">
+            <td colspan="4" class="text-center py-4">
+              No external storages configured.
+            </td>
+          </tr>
+          <tr v-for="ds in datastores" :key="ds.name">
+            <td>{{ ds.name }}</td>
+            <td>
+              <span v-if="editingName !== ds.name">{{ ds.mount_point }}</span>
+              <v-text-field
+                v-else
+                v-model="editForm.mountPoint"
+                variant="underlined"
+                density="compact"
+                hide-details
+                style="min-width: 180px"
+              />
+            </td>
+            <td>
+              <span v-if="editingName !== ds.name">{{ ds.description }}</span>
+              <v-text-field
+                v-else
+                v-model="editForm.description"
+                variant="underlined"
+                density="compact"
+                hide-details
+                style="min-width: 160px"
+              />
+            </td>
+            <td>
+              <template v-if="editingName !== ds.name">
+                <v-btn
+                  icon
+                  variant="flat"
+                  size="small"
+                  @click="startEdit(ds)"
+                >
+                  <v-icon size="small">mdi-pencil-outline</v-icon>
+                </v-btn>
+                <v-btn
+                  icon
+                  variant="flat"
+                  size="small"
+                  @click="deleteDatastore(ds.name)"
+                >
+                  <v-icon size="small">mdi-trash-can-outline</v-icon>
+                </v-btn>
+              </template>
+              <template v-else>
+                <v-btn
+                  icon
+                  variant="flat"
+                  size="small"
+                  @click="saveEdit(ds.name)"
+                >
+                  <v-icon size="small">mdi-check</v-icon>
+                </v-btn>
+                <v-btn
+                  icon
+                  variant="flat"
+                  size="small"
+                  @click="editingName = null"
+                >
+                  <v-icon size="small">mdi-close</v-icon>
+                </v-btn>
+              </template>
+            </td>
+          </tr>
+        </tbody>
+      </v-table>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import RestApiClient from "@/RestApiClient";
+
+export default {
+  name: "ExternalStorageManager",
+  data() {
+    return {
+      dialog: false,
+      datastores: [],
+      isLoading: false,
+      errorMessage: "",
+      showCreateForm: false,
+      createForm: { name: "", mountPoint: "", description: "" },
+      editingName: null,
+      editForm: { mountPoint: "", description: "" },
+    };
+  },
+  methods: {
+    open() {
+      this.dialog = true;
+      this.loadDatastores();
+    },
+    loadDatastores() {
+      this.isLoading = true;
+      RestApiClient.getDatastores()
+        .then((data) => {
+          this.datastores = data;
+        })
+        .catch(() => {
+          this.errorMessage = "Failed to load datastores.";
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
+    },
+    resetCreateForm() {
+      this.createForm = { name: "", mountPoint: "", description: "" };
+    },
+    createDatastore() {
+      const { name, mountPoint, description } = this.createForm;
+      RestApiClient.createDatastore(name, mountPoint, description)
+        .then((ds) => {
+          this.datastores.push(ds);
+          this.showCreateForm = false;
+          this.resetCreateForm();
+        })
+        .catch((err) => {
+          this.errorMessage =
+            err?.response?.data?.detail || "Failed to create datastore.";
+        });
+    },
+    startEdit(ds) {
+      this.editingName = ds.name;
+      this.editForm = {
+        mountPoint: ds.mount_point,
+        description: ds.description || "",
+      };
+    },
+    saveEdit(name) {
+      const requestBody = {
+        mount_point: this.editForm.mountPoint,
+        description: this.editForm.description,
+      };
+      RestApiClient.updateDatastore(name, requestBody)
+        .then((updated) => {
+          const idx = this.datastores.findIndex((d) => d.name === name);
+          if (idx !== -1) this.datastores[idx] = updated;
+          this.editingName = null;
+        })
+        .catch((err) => {
+          this.errorMessage =
+            err?.response?.data?.detail || "Failed to update datastore.";
+        });
+    },
+    deleteDatastore(name) {
+      if (!confirm(`Delete external storage "${name}"?`)) return;
+      RestApiClient.deleteDatastore(name)
+        .then(() => {
+          this.datastores = this.datastores.filter((d) => d.name !== name);
+        })
+        .catch((err) => {
+          const status = err?.response?.status;
+          if (status === 409) {
+            this.errorMessage = `Cannot delete "${name}": files are still linked to this storage.`;
+          } else {
+            this.errorMessage =
+              err?.response?.data?.detail || "Failed to delete datastore.";
+          }
+        });
+    },
+  },
+  expose: ["open"],
+};
+</script>

--- a/src/components/ExternalStorageManager.vue
+++ b/src/components/ExternalStorageManager.vue
@@ -141,7 +141,14 @@ limitations under the License.
             </td>
           </tr>
           <tr v-for="ds in datastores" :key="ds.name">
-            <td>{{ ds.name }}</td>
+            <td>
+              <span v-if="editingName !== ds.name">{{ ds.name }}</span>
+              <v-tooltip v-else location="top" text="Storage name cannot be changed after creation.">
+                <template v-slot:activator="{ props }">
+                  <span v-bind="props" class="text-medium-emphasis" style="cursor: not-allowed">{{ ds.name }}</span>
+                </template>
+              </v-tooltip>
+            </td>
             <td>
               <span v-if="editingName !== ds.name">{{ ds.mount_point }}</span>
               <v-text-field

--- a/src/components/FolderList.vue
+++ b/src/components/FolderList.vue
@@ -69,6 +69,13 @@ limitations under the License.
           >
             {{ item.display_name }}
           </router-link>
+          <v-chip
+            v-if="item.is_external"
+            size="x-small"
+            color="grey"
+            label
+            class="ml-2"
+          >external</v-chip>
         </span>
         <span v-else>
           <v-icon
@@ -137,7 +144,7 @@ limitations under the License.
       <!-- Actions -->
       <template v-slot:item.actions="{ item }">
         <v-btn
-          v-if="item.user.id === currentUser.id"
+          v-if="item.user.id === currentUser.id && !item.is_external"
           icon
           variant="flat"
           size="small"

--- a/src/components/FolderList.vue
+++ b/src/components/FolderList.vue
@@ -34,8 +34,16 @@ limitations under the License.
       <template v-slot:body.prepend v-if="folder">
         <tr>
           <td>
+            <!-- Inside a virtual external subfolder: go up in virtual path -->
+            <span
+              v-if="virtualPath"
+              style="text-decoration: none; color: inherit; cursor: pointer"
+              @click="$emit('virtual-folder-back')"
+            >
+              <v-icon color="info" class="mr-2 mt-n1">mdi-folder</v-icon> ..
+            </span>
             <router-link
-              v-if="folder.parent"
+              v-else-if="folder.parent"
               style="text-decoration: none; color: inherit"
               :to="{ name: 'folder', params: { folderId: folder.parent.id } }"
             >
@@ -76,6 +84,14 @@ limitations under the License.
             label
             class="ml-2"
           >external</v-chip>
+        </span>
+        <!-- Virtual external subfolder (no real DB ID, no route) -->
+        <span v-else-if="item.is_virtual_external_folder">
+          <v-icon class="mr-3 mt-n1" color="info">mdi-folder-network-outline</v-icon>
+          <span
+            style="cursor: pointer"
+            @click="$emit('virtual-folder-enter', item.display_name)"
+          >{{ item.display_name }}</span>
         </span>
         <span v-else>
           <v-icon
@@ -127,9 +143,10 @@ limitations under the License.
 
       <!-- Time -->
       <template v-slot:item.updated_at="{ item }">
-        <span :title="item.updated_at">{{
+        <span v-if="!item.is_virtual_external_folder" :title="item.updated_at">{{
           $filters.formatTime(item.updated_at)
         }}</span>
+        <span v-else>—</span>
       </template>
 
       <!-- Owner -->
@@ -168,7 +185,12 @@ export default {
     items: Array,
     isLoading: Boolean,
     folder: Object,
+    virtualPath: {
+      type: String,
+      default: "",
+    },
   },
+  emits: ["file-deleted", "folder-deleted", "selected-files", "virtual-folder-enter", "virtual-folder-back"],
   components: {
     ProfilePicture,
   },

--- a/src/components/MountExternalStorageDialog.vue
+++ b/src/components/MountExternalStorageDialog.vue
@@ -1,0 +1,137 @@
+<!--
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<template>
+  <v-dialog v-model="dialog" width="500">
+    <v-card>
+      <v-card-title>Mount external storage</v-card-title>
+      <div class="pa-4">
+        <v-alert
+          v-if="errorMessage"
+          type="error"
+          variant="tonal"
+          density="compact"
+          closable
+          class="mb-4"
+          @click:close="errorMessage = ''"
+          >{{ errorMessage }}</v-alert
+        >
+
+        <v-form @submit.prevent @keyup.enter="submit()">
+          <v-select
+            v-model="form.datastoreName"
+            :items="datastores"
+            item-title="name"
+            item-value="name"
+            label="External storage *"
+            variant="outlined"
+            density="compact"
+            class="mb-3"
+            hide-details
+          />
+
+          <v-text-field
+            v-model="form.basePath"
+            label="Base path (optional)"
+            variant="outlined"
+            density="compact"
+            class="mb-4"
+            hide-details
+            placeholder="e.g. cases/2024"
+            hint="Path within the storage to use as root. Leave empty for the storage root."
+          />
+        </v-form>
+
+        <v-btn
+          variant="flat"
+          color="primary"
+          class="text-none mr-2"
+          :disabled="!form.datastoreName || isSubmitting"
+          :loading="isSubmitting"
+          @click="submit()"
+          >Mount</v-btn
+        >
+        <v-btn variant="text" class="text-none" @click="dialog = false"
+          >Cancel</v-btn
+        >
+      </div>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import RestApiClient from "@/RestApiClient";
+
+export default {
+  name: "MountExternalStorageDialog",
+  props: {
+    folder: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ["mounted"],
+  data() {
+    return {
+      dialog: false,
+      datastores: [],
+      errorMessage: "",
+      isSubmitting: false,
+      form: {
+        datastoreName: null,
+        basePath: "",
+      },
+    };
+  },
+  methods: {
+    open() {
+      this.dialog = true;
+      this.errorMessage = "";
+      this.form = {
+        datastoreName: this.folder.external_storage_name || null,
+        basePath: this.folder.external_base_path || "",
+      };
+      RestApiClient.getDatastores()
+        .then((data) => {
+          this.datastores = data;
+        })
+        .catch(() => {
+          this.errorMessage = "Failed to load datastores.";
+        });
+    },
+    submit() {
+      if (!this.form.datastoreName) return;
+      this.isSubmitting = true;
+      this.errorMessage = "";
+      RestApiClient.updateFolder(this.folder, {
+        external_storage_name: this.form.datastoreName,
+        external_base_path: this.form.basePath || null,
+      })
+        .then((updatedFolder) => {
+          this.$emit("mounted", updatedFolder);
+          this.dialog = false;
+        })
+        .catch((err) => {
+          const detail = err?.response?.data?.detail;
+          this.errorMessage = detail || "Failed to mount external storage.";
+        })
+        .finally(() => {
+          this.isSubmitting = false;
+        });
+    },
+  },
+  expose: ["open"],
+};
+</script>

--- a/src/components/MountExternalStorageDialog.vue
+++ b/src/components/MountExternalStorageDialog.vue
@@ -29,6 +29,16 @@ limitations under the License.
           >{{ errorMessage }}</v-alert
         >
 
+        <v-alert
+          v-if="replacingExistingMount"
+          type="warning"
+          variant="tonal"
+          density="compact"
+          class="mb-4"
+        >
+          This folder already has <strong>{{ folder.external_storage_name }}</strong> mounted. Saving will replace it.
+        </v-alert>
+
         <v-form @submit.prevent @keyup.enter="submit()">
           <v-select
             v-model="form.datastoreName"
@@ -94,6 +104,15 @@ export default {
         basePath: "",
       },
     };
+  },
+  computed: {
+    replacingExistingMount() {
+      return (
+        this.folder.external_storage_name &&
+        this.form.datastoreName &&
+        this.form.datastoreName !== this.folder.external_storage_name
+      );
+    },
   },
   methods: {
     open() {

--- a/src/components/SystemMenu.vue
+++ b/src/components/SystemMenu.vue
@@ -18,7 +18,7 @@ limitations under the License.
     <template v-slot:activator="{ props }">
       <v-icon v-bind="props" class="ml-3">mdi-dots-vertical</v-icon>
     </template>
-    <v-list width="200">
+    <v-list width="220">
       <toggle-theme />
       <v-list-item :to="'/metrics'">
         <template v-slot:prepend>

--- a/src/components/SystemMenu.vue
+++ b/src/components/SystemMenu.vue
@@ -26,13 +26,21 @@ limitations under the License.
         </template>
         <v-list-item-title>Metrics</v-list-item-title>
       </v-list-item>
+      <v-list-item @click="$refs.externalStorageManager.open()">
+        <template v-slot:prepend>
+          <v-icon size="small">mdi-database-arrow-right-outline</v-icon>
+        </template>
+        <v-list-item-title>External storages</v-list-item-title>
+      </v-list-item>
     </v-list>
   </v-menu>
+  <external-storage-manager ref="externalStorageManager" />
 </template>
 
 <script>
 import { useTheme } from "vuetify";
 import ToggleTheme from "./ToggleTheme.vue";
+import ExternalStorageManager from "./ExternalStorageManager.vue";
 
 export default {
   data() {
@@ -42,6 +50,7 @@ export default {
   },
   components: {
     ToggleTheme,
+    ExternalStorageManager,
   },
 };
 </script>

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -432,6 +432,14 @@ limitations under the License.
                   <td>Original Path</td>
                   <td>{{ file.original_path }}</td>
                 </tr>
+                <tr v-if="file.is_external">
+                  <td>Storage</td>
+                  <td>{{ file.external_storage_name }}</td>
+                </tr>
+                <tr v-if="file.is_external && file.external_relative_path">
+                  <td>External path</td>
+                  <td>{{ file.external_relative_path }}</td>
+                </tr>
               </tbody>
             </v-table>
           </v-card>
@@ -545,6 +553,7 @@ export default {
       );
     },
     canEdit() {
+      if (this.file?.is_external) return false;
       return this.myRole.role === "Owner" || this.myRole.role === "Editor";
     },
     isOwner() {

--- a/src/views/File.vue
+++ b/src/views/File.vue
@@ -553,7 +553,6 @@ export default {
       );
     },
     canEdit() {
-      if (this.file?.is_external) return false;
       return this.myRole.role === "Owner" || this.myRole.role === "Editor";
     },
     isOwner() {

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -103,6 +103,13 @@ limitations under the License.
     @file-added="onExternalFileAdded($event)"
   />
 
+  <!-- Mount external storage dialog -->
+  <mount-external-storage-dialog
+    ref="mountExternalStorageDialog"
+    :folder="folder"
+    @mounted="onExternalStorageMounted($event)"
+  />
+
   <!-- Share folder dialog -->
   <v-dialog v-model="showSharingDialog" width="400">
     <v-card width="500" class="mx-auto">
@@ -453,6 +460,19 @@ limitations under the License.
       </h3>
     </v-hover>
     <h2 v-else>{{ folder.display_name }}</h2>
+
+    <v-chip
+      v-if="folder.external_storage_name"
+      size="small"
+      color="info"
+      variant="tonal"
+      prepend-icon="mdi-database-arrow-right-outline"
+      class="ml-3"
+      closable
+      close-icon="mdi-link-off"
+      title="Unmount external storage"
+      @click:close="unmountExternalStorage()"
+    >{{ folder.external_storage_name }}</v-chip>
   </span>
 
   <div v-if="folder.is_deleted">
@@ -489,6 +509,14 @@ limitations under the License.
         prepend-icon="mdi-database-arrow-right-outline"
         @click="$refs.addExternalFileDialog.open()"
         >Add from external storage</v-btn
+      >
+      <v-btn
+        v-if="!isWorkflowFolder && canEdit"
+        variant="outlined"
+        class="text-none mr-2 custom-border-color"
+        prepend-icon="mdi-database-sync-outline"
+        @click="$refs.mountExternalStorageDialog.open()"
+        >Mount external storage</v-btn
       >
       <v-menu v-if="files.length && canEdit">
         <template v-slot:activator="{ props }">
@@ -764,13 +792,36 @@ limitations under the License.
           Workflow results
         </v-card-title>
 
+        <!-- Virtual external path breadcrumb -->
+        <div v-if="externalVirtualPath" class="d-flex align-center mb-2 text-caption text-medium-emphasis">
+          <v-icon size="x-small" class="mr-1">mdi-database-arrow-right-outline</v-icon>
+          <span
+            class="text-primary"
+            style="cursor: pointer"
+            @click="externalVirtualPath = ''"
+          >{{ folder.external_storage_name }}</span>
+          <template v-for="(seg, idx) in externalVirtualPath.split('/')" :key="idx">
+            <v-icon size="x-small" class="mx-1">mdi-chevron-right</v-icon>
+            <span
+              v-if="idx < externalVirtualPath.split('/').length - 1"
+              class="text-primary"
+              style="cursor: pointer"
+              @click="externalVirtualPath = externalVirtualPath.split('/').slice(0, idx + 1).join('/')"
+            >{{ seg }}</span>
+            <span v-else>{{ seg }}</span>
+          </template>
+        </div>
+
         <folder-list
-          :items="items"
+          :items="virtualDisplayItems"
           :is-loading="isLoading"
           :folder="folder"
+          :virtual-path="externalVirtualPath"
           @file-deleted="removeFile($event)"
           @folder-deleted="removeFolder($event)"
           @selected-files="selectedFiles = $event"
+          @virtual-folder-enter="onVirtualFolderEnter($event)"
+          @virtual-folder-back="onVirtualFolderBack()"
         ></folder-list>
       </div>
     </div>
@@ -793,6 +844,7 @@ import FolderList from "@/components/FolderList";
 import ProfilePicture from "@/components/ProfilePicture.vue";
 import UploadFile from "@/components/UploadFile";
 import AddExternalFileDialog from "@/components/AddExternalFileDialog.vue";
+import MountExternalStorageDialog from "@/components/MountExternalStorageDialog.vue";
 import Workflow from "@/components/Workflow.vue";
 import WorkflowCanvas from "@/components/WorkflowCanvas/WorkflowCanvas.vue";
 import WorkflowReport from "@/components/WorkflowReport.vue";
@@ -804,6 +856,7 @@ export default {
     ProfilePicture,
     UploadFile,
     AddExternalFileDialog,
+    MountExternalStorageDialog,
     Workflow,
     WorkflowCanvas,
     WorkflowReport,
@@ -839,6 +892,7 @@ export default {
       showRenameWorkflowDialog: false,
       showWorkflowReportDialog: false,
 
+      externalVirtualPath: "",
       workflowReportMarkdown: "",
       isGeneratingReport: false,
       newFolderForm: {
@@ -883,6 +937,54 @@ export default {
     },
     items() {
       return this.folders.concat(this.files);
+    },
+    virtualDisplayItems() {
+      // Only activate virtual grouping when some external files carry a relative path
+      // that contains a directory separator.
+      const hasPathsWithDirs = this.files.some(
+        (f) => f.is_external && f.external_relative_path && f.external_relative_path.includes("/")
+      );
+      if (!hasPathsWithDirs && !this.externalVirtualPath) {
+        return this.items;
+      }
+
+      const prefix = this.externalVirtualPath ? this.externalVirtualPath + "/" : "";
+      const virtualFolderNames = new Set();
+      const directExternalFiles = [];
+
+      for (const file of this.files) {
+        if (!file.is_external || !file.external_relative_path) continue;
+        const rel = file.external_relative_path;
+        if (!rel.startsWith(prefix)) continue;
+        const remainder = rel.slice(prefix.length);
+        const slashIdx = remainder.indexOf("/");
+        if (slashIdx === -1) {
+          directExternalFiles.push(file);
+        } else {
+          virtualFolderNames.add(remainder.slice(0, slashIdx));
+        }
+      }
+
+      const virtualFolders = [...virtualFolderNames].sort().map((name) => ({
+        id: "__virtual__" + name,
+        display_name: name,
+        is_virtual_external_folder: true,
+        user: { id: null, display_name: "" },
+        workflows: [],
+        updated_at: null,
+        selectable: false,
+      }));
+
+      if (this.externalVirtualPath) {
+        // Inside a virtual directory: only virtual subfolders and their direct files
+        return [...virtualFolders, ...directExternalFiles];
+      }
+
+      // At root: real folders, non-external + path-less external files, then virtual tree
+      const nonExternalOrPathless = this.files.filter(
+        (f) => !f.is_external || !f.external_relative_path
+      );
+      return [...this.folders, ...nonExternalOrPathless, ...virtualFolders, ...directExternalFiles];
     },
     isWorkflowFolder() {
       if (!this.folder.workflows) {
@@ -965,6 +1067,36 @@ export default {
     },
     onExternalFileAdded(file) {
       this.files.push(file);
+    },
+    onVirtualFolderEnter(name) {
+      this.externalVirtualPath = this.externalVirtualPath
+        ? this.externalVirtualPath + "/" + name
+        : name;
+    },
+    onVirtualFolderBack() {
+      const lastSlash = this.externalVirtualPath.lastIndexOf("/");
+      this.externalVirtualPath =
+        lastSlash === -1 ? "" : this.externalVirtualPath.slice(0, lastSlash);
+    },
+    onExternalStorageMounted(updatedFolder) {
+      this.folder.external_storage_name = updatedFolder.external_storage_name;
+      this.folder.external_base_path = updatedFolder.external_base_path;
+      this.refreshFileListing();
+    },
+    unmountExternalStorage() {
+      RestApiClient.updateFolder(this.folder, {
+        external_storage_name: null,
+        external_base_path: null,
+      }).then((updatedFolder) => {
+        this.folder.external_storage_name = updatedFolder.external_storage_name;
+        this.folder.external_base_path = updatedFolder.external_base_path;
+        this.refreshFileListing();
+      }).catch(() => {
+        this.$eventBus.emit("showSnackbar", {
+          message: "Failed to unmount external storage.",
+          color: "error",
+        });
+      });
     },
     searchUsers: _.debounce(function (query) {
       RestApiClient.searchUsers(query).then((response) => {
@@ -1217,6 +1349,7 @@ export default {
   },
   watch: {
     "$route.params": function () {
+      this.externalVirtualPath = "";
       this.getFolder();
     },
   },

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -939,11 +939,25 @@ export default {
       return this.folders.concat(this.files);
     },
     virtualDisplayItems() {
-      // Only activate virtual grouping when some external files carry a relative path
-      // that contains a directory separator.
-      const hasPathsWithDirs = this.files.some(
-        (f) => f.is_external && f.external_relative_path && f.external_relative_path.includes("/")
-      );
+      // Strip the folder's external_base_path prefix from a file's external_relative_path
+      // so that files registered under the base path appear at the virtual root, not nested
+      // inside a virtual folder named after the base path itself.
+      const basePath = this.folder.external_base_path
+        ? this.folder.external_base_path.replace(/\/$/, "") + "/"
+        : "";
+      const stripBasePath = (relPath) => {
+        if (basePath && relPath.startsWith(basePath)) {
+          return relPath.slice(basePath.length);
+        }
+        return relPath;
+      };
+
+      // Only activate virtual grouping when some external files (after stripping base path)
+      // still contain a directory separator.
+      const hasPathsWithDirs = this.files.some((f) => {
+        if (!f.is_external || !f.external_relative_path) return false;
+        return stripBasePath(f.external_relative_path).includes("/");
+      });
       if (!hasPathsWithDirs && !this.externalVirtualPath) {
         return this.items;
       }
@@ -954,7 +968,7 @@ export default {
 
       for (const file of this.files) {
         if (!file.is_external || !file.external_relative_path) continue;
-        const rel = file.external_relative_path;
+        const rel = stripBasePath(file.external_relative_path);
         if (!rel.startsWith(prefix)) continue;
         const remainder = rel.slice(prefix.length);
         const slashIdx = remainder.indexOf("/");

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -485,7 +485,7 @@ limitations under the License.
   <div v-if="no_access" class="mt-2">You don't have access to this folder.</div>
   <div v-else>
     <!-- Button row -->
-    <div class="mt-3">
+    <div class="mt-3 d-flex align-center">
       <v-btn
         v-if="!isWorkflowFolder && canEdit"
         variant="outlined"
@@ -518,17 +518,6 @@ limitations under the License.
         @click="$refs.mountExternalStorageDialog.open()"
         >Mount external storage</v-btn
       >
-      <v-btn
-        v-if="folder.external_storage_name"
-        icon
-        variant="outlined"
-        class="mr-2 custom-border-color"
-        :loading="isRefreshingExternalFiles"
-        title="Refresh external files"
-        @click="refreshExternalFiles()"
-      >
-        <v-icon>mdi-refresh</v-icon>
-      </v-btn>
       <v-menu v-if="files.length && canEdit">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -591,6 +580,16 @@ limitations under the License.
         :to="{ name: 'investigation', params: { folderId: folderId } }"
         prepend-icon="mdi-feature-search-outline"
         >Investigate</v-btn
+      >
+      <v-btn
+        v-if="folder.external_storage_name"
+        variant="outlined"
+        class="text-none custom-border-color"
+        style="margin-left: auto"
+        prepend-icon="mdi-refresh"
+        :loading="isRefreshingExternalFiles"
+        @click="refreshExternalFiles()"
+        >Refresh</v-btn
       >
     </div>
 
@@ -1095,6 +1094,7 @@ export default {
       this.files.push(file);
     },
     refreshExternalFiles() {
+      this.externalVirtualPath = "";
       this.isRefreshingExternalFiles = true;
       RestApiClient.getFiles(this.folderId)
         .then((response) => {
@@ -1124,6 +1124,7 @@ export default {
         external_storage_name: null,
         external_base_path: null,
       }).then((updatedFolder) => {
+        this.externalVirtualPath = "";
         this.folder.external_storage_name = updatedFolder.external_storage_name;
         this.folder.external_base_path = updatedFolder.external_base_path;
         this.refreshFileListing();

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -96,6 +96,13 @@ limitations under the License.
     </v-card>
   </v-dialog>
 
+  <!-- Add from external storage dialog -->
+  <add-external-file-dialog
+    ref="addExternalFileDialog"
+    :folder-id="folderId"
+    @file-added="onExternalFileAdded($event)"
+  />
+
   <!-- Share folder dialog -->
   <v-dialog v-model="showSharingDialog" width="400">
     <v-card width="500" class="mx-auto">
@@ -475,6 +482,14 @@ limitations under the License.
         @click="showUpload = !showUpload"
         >Upload files</v-btn
       >
+      <v-btn
+        v-if="!isWorkflowFolder && canEdit"
+        variant="outlined"
+        class="text-none mr-2 custom-border-color"
+        prepend-icon="mdi-database-arrow-right-outline"
+        @click="$refs.addExternalFileDialog.open()"
+        >Add from external storage</v-btn
+      >
       <v-menu v-if="files.length && canEdit">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -766,6 +781,11 @@ limitations under the License.
 import _ from "lodash";
 import { mapActions, mapState } from "pinia";
 
+// Module-level cache: persists across component re-creations (i.e. navigation).
+// The GET /folders/{id}/files/ list endpoint may omit is_external, so we cache
+// which file IDs are external and restore the flag after every getFiles() call.
+const externalFilesCache = new Map(); // key: folderId → value: Set<fileId>
+
 import RestApiClient from "@/RestApiClient";
 import { useAppStore } from "@/stores/app";
 import { useUserStore } from "@/stores/user";
@@ -777,6 +797,7 @@ import Breadcrumbs from "@/components/Breadcrumbs";
 import FolderList from "@/components/FolderList";
 import ProfilePicture from "@/components/ProfilePicture.vue";
 import UploadFile from "@/components/UploadFile";
+import AddExternalFileDialog from "@/components/AddExternalFileDialog.vue";
 import Workflow from "@/components/Workflow.vue";
 import WorkflowCanvas from "@/components/WorkflowCanvas/WorkflowCanvas.vue";
 import WorkflowReport from "@/components/WorkflowReport.vue";
@@ -787,6 +808,7 @@ export default {
     FolderList,
     ProfilePicture,
     UploadFile,
+    AddExternalFileDialog,
     Workflow,
     WorkflowCanvas,
     WorkflowReport,
@@ -943,6 +965,34 @@ export default {
       createWorkflowTemplate: "createWorkflowTemplate",
       renameWorkflowFromStore: "renameWorkflow",
     }),
+    // Restore is_external from the module-level cache for files that the list
+    // endpoint may have returned without the field, then update the cache with
+    // any new information returned by the API.
+    setFilesFromApiResponse(files) {
+      const cached = externalFilesCache.get(this.folderId);
+      if (cached && cached.size > 0) {
+        this.files = files.map((f) =>
+          cached.has(f.id) ? { ...f, is_external: true } : f,
+        );
+      } else {
+        this.files = files;
+      }
+      // Persist any is_external flags that the API did return.
+      const externalIds = new Set(
+        this.files.filter((f) => f.is_external).map((f) => f.id),
+      );
+      if (externalIds.size > 0) {
+        externalFilesCache.set(this.folderId, externalIds);
+      }
+    },
+    onExternalFileAdded(file) {
+      this.files.push(file);
+      if (file.is_external) {
+        const cached = externalFilesCache.get(this.folderId) || new Set();
+        cached.add(file.id);
+        externalFilesCache.set(this.folderId, cached);
+      }
+    },
     searchUsers: _.debounce(function (query) {
       RestApiClient.searchUsers(query).then((response) => {
         this.searchUserResult = response;
@@ -958,7 +1008,7 @@ export default {
     },
     updateFilesArray() {
       RestApiClient.getFiles(this.folderId).then((response) => {
-        this.files = response;
+        this.setFilesFromApiResponse(response);
       });
     },
     toggleFullScreen() {
@@ -1049,7 +1099,7 @@ export default {
     },
     refreshFileListing() {
       RestApiClient.getFiles(this.folderId).then((response) => {
-        this.files = response;
+        this.setFilesFromApiResponse(response);
       });
     },
     getFolder() {
@@ -1064,7 +1114,7 @@ export default {
               this.folder.workflows[0].display_name;
           }
           RestApiClient.getFiles(this.folderId).then((response) => {
-            this.files = response;
+            this.setFilesFromApiResponse(response);
           });
           RestApiClient.getFolders(this.folderId)
             .then((response) => {

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -518,6 +518,17 @@ limitations under the License.
         @click="$refs.mountExternalStorageDialog.open()"
         >Mount external storage</v-btn
       >
+      <v-btn
+        v-if="folder.external_storage_name"
+        icon
+        variant="outlined"
+        class="mr-2 custom-border-color"
+        :loading="isRefreshingExternalFiles"
+        title="Refresh external files"
+        @click="refreshExternalFiles()"
+      >
+        <v-icon>mdi-refresh</v-icon>
+      </v-btn>
       <v-menu v-if="files.length && canEdit">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -893,6 +904,7 @@ export default {
       showWorkflowReportDialog: false,
 
       externalVirtualPath: "",
+      isRefreshingExternalFiles: false,
       workflowReportMarkdown: "",
       isGeneratingReport: false,
       newFolderForm: {
@@ -1081,6 +1093,16 @@ export default {
     },
     onExternalFileAdded(file) {
       this.files.push(file);
+    },
+    refreshExternalFiles() {
+      this.isRefreshingExternalFiles = true;
+      RestApiClient.getFiles(this.folderId)
+        .then((response) => {
+          this.setFilesFromApiResponse(response);
+        })
+        .finally(() => {
+          this.isRefreshingExternalFiles = false;
+        });
     },
     onVirtualFolderEnter(name) {
       this.externalVirtualPath = this.externalVirtualPath

--- a/src/views/Folder.vue
+++ b/src/views/Folder.vue
@@ -781,11 +781,6 @@ limitations under the License.
 import _ from "lodash";
 import { mapActions, mapState } from "pinia";
 
-// Module-level cache: persists across component re-creations (i.e. navigation).
-// The GET /folders/{id}/files/ list endpoint may omit is_external, so we cache
-// which file IDs are external and restore the flag after every getFiles() call.
-const externalFilesCache = new Map(); // key: folderId → value: Set<fileId>
-
 import RestApiClient from "@/RestApiClient";
 import { useAppStore } from "@/stores/app";
 import { useUserStore } from "@/stores/user";
@@ -965,33 +960,11 @@ export default {
       createWorkflowTemplate: "createWorkflowTemplate",
       renameWorkflowFromStore: "renameWorkflow",
     }),
-    // Restore is_external from the module-level cache for files that the list
-    // endpoint may have returned without the field, then update the cache with
-    // any new information returned by the API.
     setFilesFromApiResponse(files) {
-      const cached = externalFilesCache.get(this.folderId);
-      if (cached && cached.size > 0) {
-        this.files = files.map((f) =>
-          cached.has(f.id) ? { ...f, is_external: true } : f,
-        );
-      } else {
-        this.files = files;
-      }
-      // Persist any is_external flags that the API did return.
-      const externalIds = new Set(
-        this.files.filter((f) => f.is_external).map((f) => f.id),
-      );
-      if (externalIds.size > 0) {
-        externalFilesCache.set(this.folderId, externalIds);
-      }
+      this.files = files;
     },
     onExternalFileAdded(file) {
       this.files.push(file);
-      if (file.is_external) {
-        const cached = externalFilesCache.get(this.folderId) || new Set();
-        cached.add(file.id);
-        externalFilesCache.set(this.folderId, cached);
-      }
     },
     searchUsers: _.debounce(function (query) {
       RestApiClient.searchUsers(query).then((response) => {


### PR DESCRIPTION
# feat: UI for external read-only datastores

## Problem

Digital forensics investigations often involve large evidence sets — disk images, memory dumps,
network captures — that already reside on network shares or object stores accessible to the
OpenRelik server. Copying those files into OpenRelik just to run workflows wastes time, storage,
and risks corrupting evidence integrity. There was no way to reference files in-place without
first uploading them.

## Solution

Three new Vue components and coordinated changes to the folder and file views allow users to:

1. **Manage external storage backends** via a Settings dialog — no copying required.
2. **Mount an entire storage (or a subdirectory of one) to a folder** so that all files under
   that path are automatically synced into the folder's file list.
3. **Register individual files** from any configured storage into a folder by browsing an
   interactive directory tree.

External files are treated as read-only references: metadata (name, path, MIME type) is stored
in OpenRelik, but the bytes stay in place on the external storage. Workers read them directly
from the mounted path, so they are valid inputs to any workflow.

## Changes

### New components

| File | Description |
|---|---|
| `src/components/ExternalStorageManager.vue` | Settings dialog for CRUD management of external storage backends; probes mount point accessibility after create/update and surfaces a warning if the volume is not reachable. |
| `src/components/AddExternalFileDialog.vue` | Interactive file-browser dialog for navigating a selected storage and registering a single file as an external reference in the current folder; supports breadcrumb navigation and shows file sizes. |
| `src/components/MountExternalStorageDialog.vue` | Dialog for mounting an external storage (or a sub-path within it) to a folder; warns the user if an existing mount will be replaced. |

### Modified components

| File | Description |
|---|---|
| `src/views/Folder.vue` | Added "Add from external storage" and "Mount external storage" toolbar buttons; renders a closable chip showing the active mount name with an unmount action; computes `virtualDisplayItems` to group mounted-storage files into a navigable virtual folder tree; renders a breadcrumb strip for the current virtual path; resets virtual path on folder navigation; adds a "Refresh" button visible when a storage is mounted. |
| `src/components/FolderList.vue` | Renders an "external" chip badge on external file entries; hides the delete button for external files; renders virtual external subfolders with `mdi-folder-network-outline`; emits `virtual-folder-enter` / `virtual-folder-back` events for virtual navigation; makes the ".." row navigate up in the virtual path (rather than routing to the real parent folder) when inside a virtual subfolder; shows "—" in the Last modified column for virtual folders. |
| `src/views/File.vue` | Details tab for external files shows two additional rows — originating storage name and relative path within that storage; "Create workflow" remains available for external files. |
| `src/RestApiClient.js` | Added five new API methods: `getDatastores()`, `createDatastore()`, `updateDatastore()`, `deleteDatastore()`, `browseDatastore()`, and `registerExternalFile()` — all targeting the `/datastores/` endpoints on the server. |

### Modified views / navigation

| File | Description |
|---|---|
| `src/components/SystemMenu.vue` | Added "External storages" menu item that opens `ExternalStorageManager`. |

## Screenshots / How to test

### Step-by-step walkthrough

**1. Create an external storage (admin setup)**

- Open the system menu (top-right) → **External storages**.
- Click **Add storage**, fill in a name (immutable after creation), the container mount
  point (e.g. `/mnt/evidence`), and an optional description.
- Click **Create**. The UI immediately probes the mount point:
  - Green alert: storage is accessible.
  - Yellow warning: storage was created but the mount point is unreachable — check
    `docker-compose.yml` and restart the container.

**2. Mount the storage to a folder**

- Open any folder → click **Mount external storage** in the toolbar.
- Select the storage from the dropdown; optionally enter a base path within the storage
  (e.g. `cases/2024`) to use as the virtual root.
- Click **Mount**. The folder refreshes and a chip (e.g. `⬡ evidence ×`) appears next to
  the folder title.

**3. Verify files appear automatically**

- The file list repopulates with all files synced from the mounted path.
- Use the **Refresh** button (far-right of the toolbar) to re-sync if the storage contents
  have changed.

**4. Navigate virtual subfolder structure**

- Files stored in subdirectories of the mount appear as virtual folders
  (`mdi-folder-network-outline` icon).
- Click a virtual folder to descend into it; a breadcrumb strip above the list shows the
  current virtual path (e.g. `evidence › 2024 › january`). Each segment is clickable for
  direct navigation.
- The ".." row navigates up in the virtual path rather than routing to the real parent folder.

**5. Add an individual file via "Add from external storage"**

- Click **Add from external storage** in the toolbar.
- Select a storage from the dropdown; the root directory loads automatically.
- Browse to the target file using the interactive tree and breadcrumbs; click the file row
  to select it. Optionally override the display name and extension.
- Click **Add file**. The file appears immediately in the folder list.

**6. Verify the "external" badge**

- External files show a grey `external` chip next to their name in the file list.
- The delete button is hidden for external entries (they are read-only references).
- External files remain selectable for bulk workflow creation.

**7. Open an external file → create a workflow**

- Click an external file to open its detail view.
- The **Details** tab shows two extra rows: **Storage** and **External path**.
- Click **Create workflow** (or select a template). The workflow is created normally;
  workers read the file directly from the mounted path.

**8. Unmount a storage**

- Click the × on the mount chip next to the folder title, or open **Mount external
  storage** again and choose a different storage.
- The file list refreshes and external-synced entries are removed.

<img width="282" height="198" alt="image" src="https://github.com/user-attachments/assets/e82742bd-bcbb-4eb2-99d1-790b63bfe699" />
<img width="695" height="372" alt="image" src="https://github.com/user-attachments/assets/47007a7d-31ef-431e-8dcf-fc73c908666a" />
<img width="941" height="135" alt="image" src="https://github.com/user-attachments/assets/e0feaa13-f5e6-4a79-83b3-52355ded3e33" />
<img width="650" height="559" alt="image" src="https://github.com/user-attachments/assets/c6c39af0-7a85-4091-b37e-3622fd78898b" />
<img width="496" height="224" alt="image" src="https://github.com/user-attachments/assets/b9f6ea88-73c6-4d9d-91d5-f4409415f129" />
<img width="849" height="211" alt="image" src="https://github.com/user-attachments/assets/bfd9ec15-e7e9-4c8b-aedf-602fff7d4d3d" />

## Notes

- **No breaking changes.** All new fields (`is_external`, `external_storage_name`,
  `external_relative_path`, `external_base_path`) are additive; existing folders and files
  are unaffected.
- **`crypto.randomUUID` requirement.** The browser API used internally requires a
  [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)
  (HTTPS or `localhost`). Deployments served over plain HTTP on a non-localhost origin will
  need to be updated to use HTTPS.
- **Companion PRs (required):**
  - `openrelik/openrelik-server` — server-side datastore model, browse endpoint, and
    `PATCH /folders/{id}` fields.
  - `openrelik/openrelik-deploy` — `docker-compose.yml` volume mount example for external
    storage paths.
- Storage name is **immutable** after creation. To rename, delete and recreate the entry.
  Deletion is blocked (HTTP 409) while files are still linked to the storage.
- **Related PRs:** [openrelik-server#180](https://github.com/openrelik/openrelik-server/pull/180), [openrelik-deploy#20](https://github.com/openrelik/openrelik-deploy/pull/20)